### PR TITLE
Add villager entity with brain-based AI system

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -31,7 +31,25 @@ jobs:
       - name: Validate Wrapper
         uses: gradle/actions/wrapper-validation@v3
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.minecraft/assets
+            .gradle
+            build/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/1.20.1' }}
+
+      - name: Build
         run: chmod u+x ./gradlew && ./gradlew build
 
       - name: Test JAR with GameTest Server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/SoSly/VillagerLiteracyProgram/tree/1.20.1)
+## [Unreleased](https://github.com/SoSly/VillageWorks/tree/1.20.1)
+
+### Added
+- A new `Villager` entity that is the basis of the mod
+- `/vw assign` command to set villager homes

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 ####################
 ## Mod Information
 ####################
-mod_version = 0.1.0-alpha
+mod_version = 0.0.0-unreleased
 mod_authors = nivthefox
 mod_group = org.sosly.villageworks
 mod_id = villageworks

--- a/src/main/java/org/sosly/villageworks/VillageWorks.java
+++ b/src/main/java/org/sosly/villageworks/VillageWorks.java
@@ -1,8 +1,18 @@
 package org.sosly.villageworks;
 
 import com.mojang.logging.LogUtils;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
+import org.sosly.villageworks.command.VillageWorksCommand;
+import org.sosly.villageworks.entity.Villager;
+import org.sosly.villageworks.registry.EntityTypes;
 
 @Mod(VillageWorks.MOD_ID)
 public class VillageWorks {
@@ -11,5 +21,28 @@ public class VillageWorks {
 
     public VillageWorks() {
         LOGGER.info("Loading VillageWorks");
+
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        EntityTypes.register(modEventBus);
+
+        modEventBus.addListener(this::setup);
+        modEventBus.addListener(this::onEntityAttributeCreation);
+
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    private void setup(final FMLCommonSetupEvent event) {
+        LOGGER.info("VillageWorks setup complete");
+    }
+
+    @SubscribeEvent
+    public void onEntityAttributeCreation(EntityAttributeCreationEvent event) {
+        event.put(EntityTypes.VILLAGER.get(), Villager.createAttributes().build());
+    }
+
+    @SubscribeEvent
+    public void onRegisterCommands(RegisterCommandsEvent event) {
+        VillageWorksCommand.register(event.getDispatcher());
     }
 }

--- a/src/main/java/org/sosly/villageworks/command/AssignCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/AssignCommand.java
@@ -1,0 +1,56 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Collection;
+
+public class AssignCommand {
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("assign")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .then(Commands.literal("bed")
+                    .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                        .executes(AssignCommand::assignBed)))));
+    }
+
+    private static int assignBed(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            BlockPos bedPos = BlockPosArgument.getBlockPos(context, "pos");
+            int assignedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    villager.setHome(bedPos);
+                    assignedCount++;
+                }
+            }
+
+            if (assignedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            final int finalAssignedCount = assignedCount;
+            final BlockPos finalBedPos = bedPos;
+            context.getSource().sendSuccess(() ->
+                Component.literal(String.format("Assigned bed at %s to %d villager(s)",
+                    finalBedPos.toShortString(), finalAssignedCount)), true);
+
+            return assignedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to assign bed: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
@@ -1,0 +1,17 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+
+public class VillageWorksCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        LiteralArgumentBuilder<CommandSourceStack> vwCommand = Commands.literal("vw")
+            .requires(source -> source.hasPermission(2));
+
+        AssignCommand.register(vwCommand);
+
+        dispatcher.register(vwCommand);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -1,0 +1,197 @@
+package org.sosly.villageworks.entity;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.entity.schedule.Activity;
+import net.minecraft.world.entity.schedule.Schedule;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BedBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BedPart;
+import org.jetbrains.annotations.NotNull;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.entity.ai.behavior.VillagerGoalPackages;
+
+import javax.annotation.Nullable;
+
+public class Villager extends PathfinderMob {
+    private static final ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = ImmutableList.of(
+        MemoryModuleType.HOME,
+        MemoryModuleType.NEAREST_LIVING_ENTITIES,
+        MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,
+        MemoryModuleType.NEAREST_PLAYERS,
+        MemoryModuleType.NEAREST_VISIBLE_PLAYER,
+        MemoryModuleType.WALK_TARGET,
+        MemoryModuleType.LOOK_TARGET,
+        MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE,
+        MemoryModuleType.PATH,
+        MemoryModuleType.HURT_BY,
+        MemoryModuleType.HURT_BY_ENTITY,
+        MemoryModuleType.NEAREST_HOSTILE,
+        MemoryModuleType.LAST_SLEPT,
+        MemoryModuleType.LAST_WOKEN
+    );
+
+    private static final ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = ImmutableList.of(
+        SensorType.NEAREST_LIVING_ENTITIES,
+        SensorType.NEAREST_PLAYERS,
+        SensorType.HURT_BY,
+        SensorType.VILLAGER_HOSTILES
+    );
+
+    public Villager(EntityType<? extends Villager> entityType, Level level) {
+        super(entityType, level);
+        ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
+        this.getNavigation().setCanFloat(true);
+        this.setCanPickUpLoot(true);
+    }
+
+    public static AttributeSupplier.Builder createAttributes() {
+        return PathfinderMob.createMobAttributes()
+            .add(Attributes.MOVEMENT_SPEED, 0.5D)
+            .add(Attributes.FOLLOW_RANGE, 48.0D)
+            .add(Attributes.MAX_HEALTH, 20.0D);
+    }
+
+    @Override
+    protected Brain.@NotNull Provider<Villager> brainProvider() {
+        return Brain.provider(MEMORY_TYPES, SENSOR_TYPES);
+    }
+
+    @Override
+    protected @NotNull Brain<?> makeBrain(@NotNull Dynamic<?> dynamic) {
+        Brain<Villager> brain = this.brainProvider().makeBrain(dynamic);
+        this.registerBrainGoals(brain);
+        return brain;
+    }
+
+    @SuppressWarnings("unchecked")
+    public @NotNull Brain<Villager> getBrain() {
+        return (Brain<Villager>) super.getBrain();
+    }
+
+    public void refreshBrain(ServerLevel serverLevel) {
+        Brain<Villager> brain = this.getBrain();
+        brain.stopAll(serverLevel, this);
+        this.brain = brain.copyWithoutBehaviors();
+        this.registerBrainGoals(this.getBrain());
+    }
+
+    private void registerBrainGoals(Brain<Villager> brain) {
+        brain.setSchedule(Schedule.VILLAGER_DEFAULT);
+
+        brain.addActivity(Activity.CORE, VillagerGoalPackages.getCorePackage());
+        brain.addActivity(Activity.IDLE, VillagerGoalPackages.getIdlePackage(0.3F));
+        brain.addActivity(Activity.REST, VillagerGoalPackages.getRestPackage(0.6F));
+        brain.addActivity(Activity.PANIC, VillagerGoalPackages.getPanicPackage(0.6F));
+
+        brain.setCoreActivities(ImmutableSet.of(Activity.CORE));
+        brain.setDefaultActivity(Activity.IDLE);
+        brain.setActiveActivityIfPossible(Activity.IDLE);
+        brain.updateActivityFromSchedule(this.level().getDayTime(), this.level().getGameTime());
+    }
+
+    @Override
+    protected void customServerAiStep() {
+        this.level().getProfiler().push("villageWorksVillagerBrain");
+        this.getBrain().tick((ServerLevel) this.level(), this);
+        this.level().getProfiler().pop();
+        super.customServerAiStep();
+    }
+
+    @Override
+    public void addAdditionalSaveData(@NotNull CompoundTag tag) {
+        super.addAdditionalSaveData(tag);
+    }
+
+    @Override
+    public void readAdditionalSaveData(@NotNull CompoundTag tag) {
+        super.readAdditionalSaveData(tag);
+        if (this.level() instanceof ServerLevel) {
+            this.refreshBrain((ServerLevel) this.level());
+        }
+    }
+
+    @Override
+    public void setLastHurtByMob(@Nullable LivingEntity livingEntity) {
+        if (livingEntity != null && this.level() instanceof ServerLevel) {
+            VillageWorks.LOGGER.info("Villager {} was hurt by {}", this, livingEntity);
+        }
+        super.setLastHurtByMob(livingEntity);
+    }
+
+    @Override
+    public boolean removeWhenFarAway(double distance) {
+        return false;
+    }
+
+    @Override
+    @Nullable
+    protected SoundEvent getAmbientSound() {
+        return SoundEvents.VILLAGER_AMBIENT;
+    }
+
+    @Override
+    protected SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
+        return SoundEvents.VILLAGER_HURT;
+    }
+
+    @Override
+    protected SoundEvent getDeathSound() {
+        return SoundEvents.VILLAGER_DEATH;
+    }
+
+    @Override
+    public void startSleeping(@NotNull BlockPos pos) {
+        super.startSleeping(pos);
+        this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level().getGameTime());
+        this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
+        this.brain.eraseMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
+    }
+
+    public void setHome(BlockPos pos) {
+        if (pos != null) {
+            BlockPos bedHeadPos = getBedHeadPosition(pos);
+            this.brain.setMemory(MemoryModuleType.HOME, GlobalPos.of(this.level().dimension(), bedHeadPos));
+            VillageWorks.LOGGER.info("Villager {} assigned home at {} (bed head: {})", this, pos, bedHeadPos);
+        } else {
+            this.brain.eraseMemory(MemoryModuleType.HOME);
+            VillageWorks.LOGGER.info("Villager {} home assignment cleared", this);
+        }
+    }
+
+    public BlockPos getHome() {
+        return this.brain.getMemory(MemoryModuleType.HOME)
+            .map(GlobalPos::pos)
+            .orElse(null);
+    }
+
+    private BlockPos getBedHeadPosition(BlockPos bedPos) {
+        BlockState blockState = this.level().getBlockState(bedPos);
+        if (blockState.getBlock() instanceof BedBlock) {
+            BedPart bedPart = blockState.getValue(BedBlock.PART);
+            if (bedPart == BedPart.FOOT) {
+                return bedPos.relative(blockState.getValue(BedBlock.FACING));
+            }
+        }
+        return bedPos;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/GoToAssignedBed.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/GoToAssignedBed.java
@@ -1,0 +1,31 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.world.entity.ai.behavior.declarative.BehaviorBuilder;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import org.sosly.villageworks.entity.Villager;
+
+public class GoToAssignedBed {
+    public static BehaviorControl<Villager> create(float speedModifier) {
+        return BehaviorBuilder.create(instance -> 
+            instance.group(
+                instance.present(MemoryModuleType.HOME),
+                instance.absent(MemoryModuleType.WALK_TARGET)
+            ).apply(instance, (home, walkTarget) -> 
+                (level, villager, gameTime) -> {
+                    GlobalPos homePos = instance.get(home);
+                    BlockPos bedPos = homePos.pos();
+                    
+                    if (!bedPos.closerToCenterThan(villager.position(), 2.0D)) {
+                        walkTarget.set(new WalkTarget(bedPos, speedModifier, 1));
+                        return true;
+                    }
+                    return false;
+                }
+            )
+        );
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/SetWalkTargetFromBlockMemory.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/SetWalkTargetFromBlockMemory.java
@@ -1,0 +1,89 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import com.mojang.datafixers.kinds.Const;
+import com.mojang.datafixers.kinds.IdF;
+import com.mojang.datafixers.kinds.OptionalBox;
+import com.mojang.datafixers.util.Unit;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.behavior.OneShot;
+import net.minecraft.world.entity.ai.behavior.declarative.BehaviorBuilder;
+import net.minecraft.world.entity.ai.behavior.declarative.MemoryAccessor;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import net.minecraft.world.entity.ai.util.DefaultRandomPos;
+import net.minecraft.world.phys.Vec3;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Optional;
+
+public class SetWalkTargetFromBlockMemory {
+
+    public static OneShot<Villager> create(MemoryModuleType<GlobalPos> memoryType, float speedModifier, int closeEnoughDistance, int tooFarDistance, int maxUnreachableTime) {
+        return BehaviorBuilder.create(instance ->
+            instance.group(
+                instance.registered(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE),
+                instance.absent(MemoryModuleType.WALK_TARGET),
+                instance.present(memoryType)
+            ).apply(instance, (cantReachMemory, walkTargetMemory, blockPosMemory) ->
+                (level, villager, gameTime) -> {
+                    GlobalPos targetPos = instance.get(blockPosMemory);
+
+                    if (!isValidTarget(level, villager, targetPos, instance, cantReachMemory, gameTime, maxUnreachableTime)) {
+                        blockPosMemory.erase();
+                        cantReachMemory.set(gameTime);
+                        return true;
+                    }
+
+                    int distance = targetPos.pos().distManhattan(villager.blockPosition());
+
+                    if (distance > tooFarDistance) {
+                        setRandomWalkTarget(villager, targetPos, speedModifier, closeEnoughDistance, walkTargetMemory, blockPosMemory, cantReachMemory, gameTime);
+                    } else if (distance > closeEnoughDistance) {
+                        walkTargetMemory.set(new WalkTarget(targetPos.pos(), speedModifier, closeEnoughDistance));
+                    }
+
+                    return true;
+                }
+            )
+        );
+    }
+
+    private static boolean isValidTarget(ServerLevel level, Villager villager, GlobalPos targetPos,
+                                       BehaviorBuilder.Instance<Villager> instance,
+                                       MemoryAccessor<OptionalBox.Mu, Long> cantReachMemory,
+                                       long gameTime, int maxUnreachableTime) {
+        if (targetPos.dimension() != level.dimension()) {
+            return false;
+        }
+
+        Optional<Long> cantReachTime = instance.tryGet(cantReachMemory);
+        return cantReachTime.isEmpty() || gameTime - cantReachTime.get() <= maxUnreachableTime;
+    }
+
+    private static void setRandomWalkTarget(Villager villager, GlobalPos targetPos, float speedModifier, int closeEnoughDistance,
+                                          MemoryAccessor<Const.Mu<Unit>, WalkTarget> walkTargetMemory, MemoryAccessor<IdF.Mu, GlobalPos> blockPosMemory,
+                                          MemoryAccessor<OptionalBox.Mu, Long> cantReachMemory, long gameTime) {
+        Vec3 walkPos = findValidWalkPosition(villager, targetPos);
+
+        if (walkPos != null) {
+            walkTargetMemory.set(new WalkTarget(walkPos, speedModifier, closeEnoughDistance));
+        } else {
+            blockPosMemory.erase();
+            cantReachMemory.set(gameTime);
+        }
+    }
+
+    private static Vec3 findValidWalkPosition(Villager villager, GlobalPos targetPos) {
+        Vec3 targetVec = Vec3.atBottomCenterOf(targetPos.pos());
+
+        for (int attempt = 0; attempt < 1000; attempt++) {
+            Vec3 walkPos = DefaultRandomPos.getPosTowards(villager, 15, 7, targetVec, Math.PI / 2F);
+            if (walkPos != null) {
+                return walkPos;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/SleepInBed.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/SleepInBed.java
@@ -1,0 +1,83 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.schedule.Activity;
+import net.minecraft.world.level.block.BedBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Optional;
+
+public class SleepInBed extends Behavior<Villager> {
+    private long nextOkStartTime;
+
+    public SleepInBed() {
+        super(ImmutableMap.of(MemoryModuleType.HOME, MemoryStatus.VALUE_PRESENT, MemoryModuleType.LAST_WOKEN, MemoryStatus.REGISTERED));
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        if (villager.isPassenger()) {
+            return false;
+        }
+        
+        GlobalPos homePos = villager.getBrain().getMemory(MemoryModuleType.HOME).get();
+        if (level.dimension() != homePos.dimension()) {
+            return false;
+        }
+        
+        Optional<Long> lastWoken = villager.getBrain().getMemory(MemoryModuleType.LAST_WOKEN);
+        if (lastWoken.isPresent()) {
+            long timeSinceWoken = level.getGameTime() - lastWoken.get();
+            if (timeSinceWoken > 0L && timeSinceWoken < 100L) {
+                return false;
+            }
+        }
+        
+        BlockState blockState = level.getBlockState(homePos.pos());
+        return homePos.pos().closerToCenterThan(villager.position(), 2.0D) 
+            && blockState.is(BlockTags.BEDS) 
+            && !blockState.getValue(BedBlock.OCCUPIED);
+    }
+
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        Optional<GlobalPos> homePos = villager.getBrain().getMemory(MemoryModuleType.HOME);
+        if (!homePos.isPresent()) {
+            return false;
+        }
+        
+        BlockPos bedPos = homePos.get().pos();
+        return villager.getBrain().isActive(Activity.REST) 
+            && villager.getY() > (double) bedPos.getY() + 0.4D 
+            && bedPos.closerToCenterThan(villager.position(), 1.14D);
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        if (gameTime > this.nextOkStartTime) {
+            BlockPos bedPos = villager.getBrain().getMemory(MemoryModuleType.HOME).get().pos();
+            villager.startSleeping(bedPos);
+        }
+    }
+
+    @Override
+    protected boolean timedOut(long gameTime) {
+        return false;
+    }
+
+    @Override
+    protected void stop(ServerLevel level, Villager villager, long gameTime) {
+        if (villager.isSleeping()) {
+            villager.stopSleeping();
+            this.nextOkStartTime = gameTime + 40L;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerGoalPackages.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerGoalPackages.java
@@ -1,0 +1,79 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.behavior.Swim;
+import net.minecraft.world.entity.ai.behavior.LookAtTargetSink;
+import net.minecraft.world.entity.ai.behavior.MoveToTargetSink;
+import net.minecraft.world.entity.ai.behavior.UpdateActivityFromSchedule;
+import net.minecraft.world.entity.ai.behavior.RandomStroll;
+import net.minecraft.world.entity.ai.behavior.RunOne;
+import net.minecraft.world.entity.ai.behavior.DoNothing;
+import net.minecraft.world.entity.ai.behavior.SetWalkTargetFromLookTarget;
+import net.minecraft.world.entity.ai.behavior.SetEntityLookTarget;
+import net.minecraft.world.entity.ai.behavior.SetWalkTargetAwayFrom;
+import net.minecraft.world.entity.ai.behavior.VillagerCalmDown;
+import net.minecraft.world.entity.ai.behavior.VillageBoundRandomStroll;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import org.sosly.villageworks.entity.Villager;
+
+public class VillagerGoalPackages {
+
+    @SuppressWarnings("unchecked")
+    public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> getCorePackage() {
+        return ImmutableList.of(
+            Pair.of(0, (BehaviorControl<? super Villager>) new Swim(0.8F)),
+            Pair.of(0, (BehaviorControl<? super Villager>) new LookAtTargetSink(45, 90)),
+            Pair.of(0, VillagerPanicTrigger.create()),
+            Pair.of(1, (BehaviorControl<? super Villager>) new MoveToTargetSink()),
+            Pair.of(1, WakeUp.create()),
+            Pair.of(99, (BehaviorControl<? super Villager>) UpdateActivityFromSchedule.create())
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> getIdlePackage(float speedModifier) {
+        return ImmutableList.of(
+            Pair.of(5, (BehaviorControl<? super Villager>) new RunOne<>(ImmutableList.of(
+                Pair.of(RandomStroll.stroll(speedModifier), 2),
+                Pair.of(SetWalkTargetFromLookTarget.create(speedModifier, 3), 2),
+                Pair.of(new DoNothing(30, 60), 1)
+            ))),
+            getMinimalLookBehavior(),
+            Pair.of(99, (BehaviorControl<? super Villager>) UpdateActivityFromSchedule.create())
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> getRestPackage(float speedModifier) {
+        return ImmutableList.of(
+            Pair.of(2, SetWalkTargetFromBlockMemory.create(MemoryModuleType.HOME, speedModifier, 1, 150, 1200)),
+            Pair.of(3, GoToAssignedBed.create(speedModifier)),
+            Pair.of(4, new SleepInBed()),
+            getMinimalLookBehavior(),
+            Pair.of(99, (BehaviorControl<? super Villager>) UpdateActivityFromSchedule.create())
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Pair<Integer, BehaviorControl<? super Villager>> getMinimalLookBehavior() {
+        return Pair.of(5, (BehaviorControl<? super Villager>) new RunOne<>(ImmutableList.of(
+            Pair.of(SetEntityLookTarget.create(net.minecraft.world.entity.EntityType.PLAYER, 8.0F), 2),
+            Pair.of(new DoNothing(30, 60), 8)
+        )));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> getPanicPackage(float speedModifier) {
+        float panicSpeed = speedModifier * 1.5F;
+        return ImmutableList.of(
+            Pair.of(0, (BehaviorControl<? super Villager>) VillagerCalmDown.create()),
+            Pair.of(0, VillagerPanicTrigger.create()),
+            Pair.of(1, (BehaviorControl<? super Villager>) SetWalkTargetAwayFrom.entity(MemoryModuleType.NEAREST_HOSTILE, panicSpeed, 6, false)),
+            Pair.of(1, (BehaviorControl<? super Villager>) SetWalkTargetAwayFrom.entity(MemoryModuleType.HURT_BY_ENTITY, panicSpeed, 6, false)),
+            Pair.of(3, (BehaviorControl<? super Villager>) VillageBoundRandomStroll.create(panicSpeed, 2, 2)),
+            getMinimalLookBehavior()
+        );
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerPanicTrigger.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerPanicTrigger.java
@@ -1,0 +1,46 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.schedule.Activity;
+import org.sosly.villageworks.entity.Villager;
+
+public class VillagerPanicTrigger extends Behavior<Villager> {
+    
+    public VillagerPanicTrigger() {
+        super(ImmutableMap.of());
+    }
+    
+    public static VillagerPanicTrigger create() {
+        return new VillagerPanicTrigger();
+    }
+    
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        return isHurt(villager) || hasHostile(villager);
+    }
+    
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        if (isHurt(villager) || hasHostile(villager)) {
+            Brain<Villager> brain = villager.getBrain();
+            if (!brain.isActive(Activity.PANIC)) {
+                brain.eraseMemory(MemoryModuleType.PATH);
+                brain.eraseMemory(MemoryModuleType.WALK_TARGET);
+                brain.eraseMemory(MemoryModuleType.LOOK_TARGET);
+            }
+            brain.setActiveActivityIfPossible(Activity.PANIC);
+        }
+    }
+    
+    private static boolean isHurt(Villager villager) {
+        return villager.getBrain().hasMemoryValue(MemoryModuleType.HURT_BY);
+    }
+    
+    private static boolean hasHostile(Villager villager) {
+        return villager.getBrain().hasMemoryValue(MemoryModuleType.NEAREST_HOSTILE);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/WakeUp.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/WakeUp.java
@@ -1,0 +1,20 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import net.minecraft.world.entity.ai.behavior.declarative.BehaviorBuilder;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.schedule.Activity;
+import org.sosly.villageworks.entity.Villager;
+
+public class WakeUp {
+    public static BehaviorControl<Villager> create() {
+        return BehaviorBuilder.create(instance -> 
+            instance.point((level, villager, gameTime) -> {
+                if (!villager.getBrain().isActive(Activity.REST) && villager.isSleeping()) {
+                    villager.stopSleeping();
+                    return true;
+                }
+                return false;
+            })
+        );
+    }
+}

--- a/src/main/java/org/sosly/villageworks/event/ClientEntities.java
+++ b/src/main/java/org/sosly/villageworks/event/ClientEntities.java
@@ -1,0 +1,18 @@
+package org.sosly.villageworks.event;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.renderer.VillagerRenderer;
+import org.sosly.villageworks.registry.EntityTypes;
+
+@Mod.EventBusSubscriber(modid = VillageWorks.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ClientEntities {
+
+    @SubscribeEvent
+    public static void registerRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerEntityRenderer(EntityTypes.VILLAGER.get(), VillagerRenderer::new);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/registry/EntityTypes.java
+++ b/src/main/java/org/sosly/villageworks/registry/EntityTypes.java
@@ -1,0 +1,26 @@
+package org.sosly.villageworks.registry;
+
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.entity.Villager;
+
+public class EntityTypes {
+    public static final DeferredRegister<EntityType<?>> ENTITY_TYPES = 
+        DeferredRegister.create(ForgeRegistries.ENTITY_TYPES, VillageWorks.MOD_ID);
+
+    public static final RegistryObject<EntityType<Villager>> VILLAGER = 
+        ENTITY_TYPES.register("villager", () -> EntityType.Builder.of(Villager::new, MobCategory.CREATURE)
+            .sized(0.6F, 1.95F)
+            .clientTrackingRange(10)
+            .build("villager"));
+
+    public static void register(IEventBus eventBus) {
+        ENTITY_TYPES.register(eventBus);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/renderer/VillagerRenderer.java
+++ b/src/main/java/org/sosly/villageworks/renderer/VillagerRenderer.java
@@ -1,0 +1,23 @@
+package org.sosly.villageworks.renderer;
+
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.entity.MobRenderer;
+import net.minecraft.client.model.VillagerModel;
+import net.minecraft.client.model.geom.ModelLayers;
+import net.minecraft.resources.ResourceLocation;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.entity.Villager;
+
+public class VillagerRenderer extends MobRenderer<Villager, VillagerModel<Villager>> {
+    private static final ResourceLocation VILLAGER_BASE_SKIN =
+        new ResourceLocation("minecraft", "textures/entity/villager/villager.png");
+
+    public VillagerRenderer(EntityRendererProvider.Context context) {
+        super(context, new VillagerModel<>(context.bakeLayer(ModelLayers.VILLAGER)), 0.5F);
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(Villager villager) {
+        return VILLAGER_BASE_SKIN;
+    }
+}


### PR DESCRIPTION
# Add villager entity with brain-based AI system
Implements complete VillageWorks villager entity extending PathfinderMob with brain-based AI, sleep behaviors, panic responses, and command support.

## Changes
- Added VillageWorks Villager entity extending PathfinderMob
- Implemented brain-based AI with memory modules and sensors
- Created sleep behavior system with bed assignment
- Added panic system for hostile mob detection and flee responses
- Implemented `/vw assign` command for bed assignment
- Added calm wandering speed for natural village atmosphere

## Related Issues
Resolves #1

## Implementation Notes
Uses vanilla Minecraft's brain-based AI system with custom behaviors. Panic system reuses vanilla behaviors like SetWalkTargetAwayFrom and VillagerCalmDown for consistency.

## Breaking Changes
None