### PR TITLE
Add villager hunger system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A new `Villager` entity that is the basis of the mod
+- Hunger system for villagers using `LivingEntityFoodData`
 - `/vw assign` command to set villager homes
+- `/vw exhaust` command to add exhaustion to villagers for testing
+- `/vw hunger` command to display villager food stats

--- a/src/main/java/org/sosly/villageworks/command/ExhaustCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ExhaustCommand.java
@@ -1,0 +1,54 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Collection;
+
+public class ExhaustCommand {
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("exhaust")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .then(Commands.argument("amount", FloatArgumentType.floatArg(0.0F, 40.0F))
+                    .executes(ExhaustCommand::addExhaustion))));
+    }
+
+    private static int addExhaustion(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            float amount = FloatArgumentType.getFloat(context, "amount");
+            int exhaustedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    villager.getFoodData().addExhaustion(amount);
+                    exhaustedCount++;
+                }
+            }
+
+            if (exhaustedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            final int finalExhaustedCount = exhaustedCount;
+            final float finalAmount = amount;
+            context.getSource().sendSuccess(() ->
+                Component.literal(String.format("Added %.1f exhaustion to %d villager(s)",
+                    finalAmount, finalExhaustedCount)), true);
+
+            return exhaustedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to add exhaustion: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/HungerCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/HungerCommand.java
@@ -1,0 +1,54 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import org.sosly.villageworks.data.LivingEntityFoodData;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Collection;
+
+public class HungerCommand {
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("hunger")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .executes(HungerCommand::displayHunger)));
+    }
+
+    private static int displayHunger(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            int checkedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    LivingEntityFoodData foodData = villager.getFoodData();
+                    
+                    context.getSource().sendSuccess(() ->
+                        Component.literal(String.format("Villager %s: Food=%d/20, Saturation=%.1f, Exhaustion=%.1f",
+                            villager.getDisplayName().getString(),
+                            foodData.getFoodLevel(),
+                            foodData.getSaturationLevel(),
+                            foodData.getExhaustionLevel())), false);
+                    
+                    checkedCount++;
+                }
+            }
+
+            if (checkedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            return checkedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to check hunger: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
@@ -11,6 +11,8 @@ public class VillageWorksCommand {
             .requires(source -> source.hasPermission(2));
 
         AssignCommand.register(vwCommand);
+        ExhaustCommand.register(vwCommand);
+        HungerCommand.register(vwCommand);
 
         dispatcher.register(vwCommand);
     }

--- a/src/main/java/org/sosly/villageworks/data/LivingEntityFoodData.java
+++ b/src/main/java/org/sosly/villageworks/data/LivingEntityFoodData.java
@@ -1,0 +1,28 @@
+package org.sosly.villageworks.data;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.food.FoodData;
+
+public class LivingEntityFoodData extends FoodData {
+    
+    public LivingEntityFoodData() {
+        super();
+    }
+    
+    public void tick(LivingEntity entity) {
+        // TODO: Implement full vanilla tick logic for living entities
+        // - Health regeneration when well-fed (saturation > 0, food >= 20)
+        // - Slower regeneration when moderately fed (food >= 18)
+        // - Starvation damage when food <= 0 (respecting difficulty)
+        // - Skip Player-specific checks like GameRules.RULE_NATURAL_REGENERATION
+        
+        if (this.getExhaustionLevel() > 4.0F) {
+            this.setExhaustion(this.getExhaustionLevel() - 4.0F);
+            if (this.getSaturationLevel() > 0.0F) {
+                this.setSaturation(Math.max(this.getSaturationLevel() - 1.0F, 0.0F));
+            } else {
+                this.setFoodLevel(Math.max(this.getFoodLevel() - 1, 0));
+            }
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -28,11 +28,14 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
 import org.jetbrains.annotations.NotNull;
 import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.data.LivingEntityFoodData;
 import org.sosly.villageworks.entity.ai.behavior.VillagerGoalPackages;
 
 import javax.annotation.Nullable;
 
 public class Villager extends PathfinderMob {
+    private final LivingEntityFoodData foodData;
+    
     private static final ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = ImmutableList.of(
         MemoryModuleType.HOME,
         MemoryModuleType.NEAREST_LIVING_ENTITIES,
@@ -59,6 +62,7 @@ public class Villager extends PathfinderMob {
 
     public Villager(EntityType<? extends Villager> entityType, Level level) {
         super(entityType, level);
+        this.foodData = new LivingEntityFoodData();
         ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
         this.getNavigation().setCanFloat(true);
         this.setCanPickUpLoot(true);
@@ -114,17 +118,20 @@ public class Villager extends PathfinderMob {
         this.level().getProfiler().push("villageWorksVillagerBrain");
         this.getBrain().tick((ServerLevel) this.level(), this);
         this.level().getProfiler().pop();
+        this.foodData.tick(this);
         super.customServerAiStep();
     }
 
     @Override
     public void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
+        this.foodData.addAdditionalSaveData(tag);
     }
 
     @Override
     public void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
+        this.foodData.readAdditionalSaveData(tag);
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());
         }
@@ -182,6 +189,10 @@ public class Villager extends PathfinderMob {
         return this.brain.getMemory(MemoryModuleType.HOME)
             .map(GlobalPos::pos)
             .orElse(null);
+    }
+
+    public LivingEntityFoodData getFoodData() {
+        return this.foodData;
     }
 
     private BlockPos getBedHeadPosition(BlockPos bedPos) {


### PR DESCRIPTION
# Add villager hunger system
Implements hunger mechanics for villagers, requiring them to track food levels and exhaustion like players but without healing or starvation damage.

## Changes
- Created LivingEntityFoodData class extending vanilla FoodData with simplified tick logic
- Integrated hunger system with Villager entity tick and NBT save/load
- Added /vw exhaust command to add exhaustion to villagers for testing
- Added /vw hunger command to display current food stats for debugging
- Updated changelog with new hunger system features

## Related Issues
Resolves #6

## Implementation Notes
Extended vanilla FoodData rather than reimplementing to reuse all existing mechanics (eating, saturation, exhaustion conversion). Simplified tick method removes Player-specific healing and starvation damage while preserving core hunger depletion mechanics. TODO added for future implementation of full living entity behavior.

## Breaking Changes
None