### PR TITLE
feat: implement HungerSensor for villager hunger state detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - A new `Villager` entity that is the basis of the mod
 - Hunger system for villagers using `LivingEntityFoodData`
-- Hunger awareness system for villagers (foundation for future food-seeking behaviors)
+- Hunger awareness system for villagers (automatically detects hunger states for AI behaviors)
 - `/vw assign` command to set villager homes
 - `/vw exhaust` command to add exhaustion to villagers for testing
 - `/vw hunger` command to display villager food stats

--- a/src/main/java/org/sosly/villageworks/VillageWorks.java
+++ b/src/main/java/org/sosly/villageworks/VillageWorks.java
@@ -14,6 +14,7 @@ import org.sosly.villageworks.command.VillageWorksCommand;
 import org.sosly.villageworks.entity.Villager;
 import org.sosly.villageworks.registry.EntityTypes;
 import org.sosly.villageworks.registry.MemoryModuleTypes;
+import org.sosly.villageworks.registry.SensorTypes;
 
 @Mod(VillageWorks.MOD_ID)
 public class VillageWorks {
@@ -27,6 +28,7 @@ public class VillageWorks {
 
         EntityTypes.register(modEventBus);
         MemoryModuleTypes.register(modEventBus);
+        SensorTypes.register(modEventBus);
 
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::onEntityAttributeCreation);

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -31,6 +31,7 @@ import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.data.LivingEntityFoodData;
 import org.sosly.villageworks.entity.ai.behavior.VillagerGoalPackages;
 import org.sosly.villageworks.registry.MemoryModuleTypes;
+import org.sosly.villageworks.registry.SensorTypes;
 
 import javax.annotation.Nullable;
 
@@ -61,7 +62,8 @@ public class Villager extends PathfinderMob {
         SensorType.NEAREST_LIVING_ENTITIES,
         SensorType.NEAREST_PLAYERS,
         SensorType.HURT_BY,
-        SensorType.VILLAGER_HOSTILES
+        SensorType.VILLAGER_HOSTILES,
+        SensorTypes.HUNGER.get()
     );
 
     public Villager(EntityType<? extends Villager> entityType, Level level) {

--- a/src/main/java/org/sosly/villageworks/entity/ai/sensor/HungerSensor.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/sensor/HungerSensor.java
@@ -1,0 +1,56 @@
+package org.sosly.villageworks.entity.ai.sensor;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.entity.Villager;
+import org.sosly.villageworks.registry.MemoryModuleTypes;
+
+import java.util.Set;
+
+public class HungerSensor extends Sensor<Villager> {
+    
+    private static final int MAX_FOOD_LEVEL = 20;
+    private static final int HUNGRY_THRESHOLD = 12;
+    private static final int STARVING_THRESHOLD = 6;
+    
+    public HungerSensor() {
+        super(600);
+    }
+
+    @Override
+    protected void doTick(ServerLevel level, Villager villager) {
+        int foodLevel = villager.getFoodData().getFoodLevel();
+        
+        boolean canEat = foodLevel < MAX_FOOD_LEVEL;
+        boolean isHungry = foodLevel < HUNGRY_THRESHOLD;
+        boolean isStarving = foodLevel < STARVING_THRESHOLD;
+        
+        updateMemoryIfChanged(villager, MemoryModuleTypes.CAN_EAT.get(), canEat);
+        updateMemoryIfChanged(villager, MemoryModuleTypes.IS_HUNGRY.get(), isHungry);
+        updateMemoryIfChanged(villager, MemoryModuleTypes.IS_STARVING.get(), isStarving);
+        
+        if (VillageWorks.LOGGER.isDebugEnabled()) {
+            VillageWorks.LOGGER.debug("HungerSensor for villager {}: foodLevel={}, canEat={}, isHungry={}, isStarving={}", 
+                villager.getId(), foodLevel, canEat, isHungry, isStarving);
+        }
+    }
+
+    private void updateMemoryIfChanged(Villager villager, MemoryModuleType<Boolean> memoryType, boolean newValue) {
+        Boolean currentValue = villager.getBrain().getMemory(memoryType).orElse(null);
+        if (currentValue == null || !currentValue.equals(newValue)) {
+            villager.getBrain().setMemory(memoryType, newValue);
+        }
+    }
+
+    @Override
+    public Set<MemoryModuleType<?>> requires() {
+        return ImmutableSet.of(
+            MemoryModuleTypes.CAN_EAT.get(),
+            MemoryModuleTypes.IS_HUNGRY.get(),
+            MemoryModuleTypes.IS_STARVING.get()
+        );
+    }
+}

--- a/src/main/java/org/sosly/villageworks/registry/SensorTypes.java
+++ b/src/main/java/org/sosly/villageworks/registry/SensorTypes.java
@@ -1,0 +1,23 @@
+package org.sosly.villageworks.registry;
+
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.entity.Villager;
+import org.sosly.villageworks.entity.ai.sensor.HungerSensor;
+
+public class SensorTypes {
+    public static final DeferredRegister<SensorType<?>> SENSOR_TYPES = 
+        DeferredRegister.create(ForgeRegistries.SENSOR_TYPES, VillageWorks.MOD_ID);
+
+    public static final RegistryObject<SensorType<HungerSensor>> HUNGER = 
+        SENSOR_TYPES.register("hunger", () -> new SensorType<>(HungerSensor::new));
+
+    public static void register(IEventBus eventBus) {
+        SENSOR_TYPES.register(eventBus);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Issue #3: Create HungerSensor
- Adds sensor that monitors villager food levels every 30 seconds (600 ticks)
- Updates hunger memory modules for AI decision making
- Optimized to only update memories when values change

## Changes
- **HungerSensor**: Monitors food levels and sets CAN_EAT, IS_HUNGRY, IS_STARVING memory states
- **SensorTypes registry**: New registry for custom sensors following Forge patterns
- **Well-named constants**: Food level thresholds (20, 12, 6) extracted to descriptive constants
- **Brain integration**: HungerSensor added to villager sensor types

## Test plan
- [x] Full project build succeeds
- [x] HungerSensor compiles and registers without errors  
- [x] Sensor properly integrated into villager brain
- [x] Memory updates optimized (only when values change)
- [x] 30-second update interval configured
- [ ] Manual testing with `/vw exhaust` and `/vw hunger` commands

Resolves #3

🤖 Generated with [Claude Code](https://claude.ai/code)