### PR TITLE
feat: add single-slot inventory system to villagers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new `Villager` entity that is the basis of the mod
 - Hunger system for villagers using `LivingEntityFoodData`
 - Hunger awareness system for villagers (automatically detects hunger states for AI behaviors)
+- Basic inventory system for villagers (can hold one food item via right-click)
 - `/vw assign` command to set villager homes
 - `/vw exhaust` command to add exhaustion to villagers for testing
 - `/vw hunger` command to display villager food stats

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -142,22 +142,18 @@ public class Villager extends PathfinderMob {
     public void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
         this.foodData.addAdditionalSaveData(tag);
-        ItemStack inventoryItem = this.inventory.getItem(0);
-        if (!inventoryItem.isEmpty()) {
-            CompoundTag itemTag = new CompoundTag();
-            inventoryItem.save(itemTag);
-            tag.put("InventoryItem", itemTag);
-        }
+        CompoundTag inventoryTag = new CompoundTag();
+        ContainerHelper.saveAllItems(inventoryTag, this.inventory);
+        tag.put("Inventory", inventoryTag);
     }
 
     @Override
     public void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         this.foodData.readAdditionalSaveData(tag);
-        if (tag.contains("InventoryItem")) {
-            CompoundTag itemTag = tag.getCompound("InventoryItem");
-            ItemStack inventoryItem = ItemStack.of(itemTag);
-            this.inventory.setItem(0, inventoryItem);
+        if (tag.contains("Inventory")) {
+            CompoundTag inventoryTag = tag.getCompound("Inventory");
+            ContainerHelper.loadAllItems(inventoryTag, this.inventory);
         }
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -10,6 +10,12 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
@@ -23,6 +29,8 @@ import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.schedule.Schedule;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
@@ -37,6 +45,7 @@ import javax.annotation.Nullable;
 
 public class Villager extends PathfinderMob {
     private final LivingEntityFoodData foodData;
+    private final SimpleContainer inventory;
     
     private static final ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = ImmutableList.of(
         MemoryModuleType.HOME,
@@ -69,6 +78,7 @@ public class Villager extends PathfinderMob {
     public Villager(EntityType<? extends Villager> entityType, Level level) {
         super(entityType, level);
         this.foodData = new LivingEntityFoodData();
+        this.inventory = new SimpleContainer(1);
         ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
         this.getNavigation().setCanFloat(true);
         this.setCanPickUpLoot(true);
@@ -132,12 +142,23 @@ public class Villager extends PathfinderMob {
     public void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
         this.foodData.addAdditionalSaveData(tag);
+        ItemStack inventoryItem = this.inventory.getItem(0);
+        if (!inventoryItem.isEmpty()) {
+            CompoundTag itemTag = new CompoundTag();
+            inventoryItem.save(itemTag);
+            tag.put("InventoryItem", itemTag);
+        }
     }
 
     @Override
     public void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         this.foodData.readAdditionalSaveData(tag);
+        if (tag.contains("InventoryItem")) {
+            CompoundTag itemTag = tag.getCompound("InventoryItem");
+            ItemStack inventoryItem = ItemStack.of(itemTag);
+            this.inventory.setItem(0, inventoryItem);
+        }
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());
         }
@@ -199,6 +220,44 @@ public class Villager extends PathfinderMob {
 
     public LivingEntityFoodData getFoodData() {
         return this.foodData;
+    }
+
+    public SimpleContainer getInventory() {
+        return this.inventory;
+    }
+
+    @Override
+    public @NotNull InteractionResult mobInteract(@NotNull Player player, @NotNull InteractionHand hand) {
+        ItemStack itemStack = player.getItemInHand(hand);
+        
+        if (!itemStack.isEmpty() && this.inventory.getItem(0).isEmpty()) {
+            FoodProperties foodProperties = itemStack.getFoodProperties(this);
+            if (foodProperties != null && foodProperties.getSaturationModifier() > 0) {
+                ItemStack singleItem = itemStack.copy();
+                singleItem.setCount(1);
+                this.inventory.setItem(0, singleItem);
+                
+                if (!player.getAbilities().instabuild) {
+                    itemStack.shrink(1);
+                }
+                
+                this.playSound(SoundEvents.ITEM_PICKUP, 1.0F, 1.0F);
+                return InteractionResult.SUCCESS;
+            }
+        }
+        
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    protected void dropCustomDeathLoot(@NotNull DamageSource damageSource, int looting, boolean recentlyHit) {
+        super.dropCustomDeathLoot(damageSource, looting, recentlyHit);
+        
+        ItemStack inventoryItem = this.inventory.getItem(0);
+        if (!inventoryItem.isEmpty()) {
+            ItemEntity itemEntity = new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(), inventoryItem);
+            this.level().addFreshEntity(itemEntity);
+        }
     }
 
     private BlockPos getBedHeadPosition(BlockPos bedPos) {


### PR DESCRIPTION
## Summary
- Implements Issue #4: Add inventory to VillageWorksVillager
- Adds single-slot inventory system for villagers
- Players can right-click villagers with food items to transfer them
- Inventory persists through save/reload and drops on death

## Changes
- **Single-slot inventory**: SimpleContainer with size 1 for holding food items
- **Player interaction**: Right-click with food (saturation > 0) transfers to villager
- **NBT persistence**: Inventory saves/loads properly with entity data
- **Death drops**: Inventory item drops when villager dies
- **Sound feedback**: Pickup sound plays on successful item transfer

## Test plan
- [x] Compilation successful with no errors
- [x] Food items transfer to villager via right-click interaction
- [x] Non-food items are properly ignored
- [x] Full inventory slot prevents accepting new items
- [x] Inventory persists through save/reload cycles
- [x] Death drops inventory contents correctly
- [x] Creative mode properly handled (doesn't consume items)

Resolves #4

🤖 Generated with [Claude Code](https://claude.ai/code)