### PR TITLE
Add village management system with admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/vw assign` command to set villager homes
 - `/vw exhaust` command to add exhaustion to villagers for testing
 - `/vw hunger` command to display villager food stats
+- `/vw village create <name> [squadius]` command to create villages with configurable boundaries
+- `/vw village remove <name>` command to remove villages by name
+- `/vw village list` command to display all villages in current dimension
+- `/vw village info [name|uuid]` command to show village information and boundaries
 - Custom `villageworks:storage_containers` block tag enables datapack creators to define which blocks villagers recognize as storage containers

--- a/src/main/java/org/sosly/villageworks/VillageWorks.java
+++ b/src/main/java/org/sosly/villageworks/VillageWorks.java
@@ -31,8 +31,6 @@ public class VillageWorks {
         MemoryModuleTypes.register(modEventBus);
         SensorTypes.register(modEventBus);
 
-        Capabilities.register();
-
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::onEntityAttributeCreation);
 

--- a/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
@@ -1,0 +1,24 @@
+package org.sosly.villageworks.api.capability;
+
+import net.minecraft.world.level.ChunkPos;
+import org.sosly.villageworks.data.VillageData;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public interface IVillagesCapability {
+
+    VillageData getVillageAt(ChunkPos pos);
+
+    UUID createVillage(ChunkPos townHallPos, String villageName, int squadius);
+
+    boolean removeVillage(UUID villageId);
+
+    boolean canClaimChunk(ChunkPos pos, UUID excludeVillageId);
+
+    Collection<VillageData> getVillages();
+
+    VillageData getVillageById(UUID villageId);
+
+    VillageData getVillageByName(String villageName);
+}

--- a/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
@@ -6,19 +6,59 @@ import org.sosly.villageworks.data.VillageData;
 import java.util.Collection;
 import java.util.UUID;
 
+/**
+ * Capability for managing all villages within a dimension.
+ * Attached to Level entities and handles village creation, removal, and lookup operations.
+ */
 public interface IVillagesCapability {
 
+    /**
+     * Finds the village that contains the specified chunk position.
+     * @param pos Chunk position to check
+     * @return Village containing the chunk, or null if no village found
+     */
     VillageData getVillageAt(ChunkPos pos);
 
+    /**
+     * Creates a new village with the specified parameters.
+     * @param townHallPos Chunk position for the village center
+     * @param villageName Unique name for the village
+     * @param squadius Square radius in chunks (1-16)
+     * @return UUID of created village, or null if creation failed
+     */
     UUID createVillage(ChunkPos townHallPos, String villageName, int squadius);
 
+    /**
+     * Removes a village by its unique identifier.
+     * @param villageId UUID of village to remove
+     * @return true if village was found and removed
+     */
     boolean removeVillage(UUID villageId);
 
+    /**
+     * Checks if a chunk can be claimed without overlapping existing villages.
+     * @param pos Chunk position to check
+     * @param excludeVillageId Village UUID to exclude from overlap check, or null
+     * @return true if chunk can be claimed
+     */
     boolean canClaimChunk(ChunkPos pos, UUID excludeVillageId);
 
+    /**
+     * @return All villages in this dimension
+     */
     Collection<VillageData> getVillages();
 
+    /**
+     * Finds a village by its unique identifier.
+     * @param villageId UUID to search for
+     * @return Village with matching UUID, or null if not found
+     */
     VillageData getVillageById(UUID villageId);
 
+    /**
+     * Finds a village by its name.
+     * @param villageName Name to search for
+     * @return Village with matching name, or null if not found
+     */
     VillageData getVillageByName(String villageName);
 }

--- a/src/main/java/org/sosly/villageworks/capability/Capabilities.java
+++ b/src/main/java/org/sosly/villageworks/capability/Capabilities.java
@@ -1,6 +1,7 @@
 package org.sosly.villageworks.capability;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
@@ -10,6 +11,9 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.capability.villages.VillagesCapability;
+import org.sosly.villageworks.capability.villages.VillagesProvider;
 import org.sosly.villageworks.capability.village.VillageCapability;
 import org.sosly.villageworks.capability.village.VillageProvider;
 
@@ -21,11 +25,14 @@ public class Capabilities {
     public static final Capability<IVillageCapability> VILLAGE_CAPABILITY =
         CapabilityManager.get(new CapabilityToken<>() {});
 
+    public static final Capability<IVillagesCapability> VILLAGES_CAPABILITY =
+        CapabilityManager.get(new CapabilityToken<>() {});
+
     private static final ResourceLocation VILLAGE_CAPABILITY_KEY =
         new ResourceLocation(VillageWorks.MOD_ID, "village_capability");
 
-    public static void register() {
-    }
+    private static final ResourceLocation VILLAGES_CAPABILITY_KEY =
+        new ResourceLocation(VillageWorks.MOD_ID, "villages_capability");
 
     @SubscribeEvent
     public static void onAttachCapabilities(AttachCapabilitiesEvent<LevelChunk> event) {
@@ -46,6 +53,22 @@ public class Capabilities {
             });
 
         event.addCapability(VILLAGE_CAPABILITY_KEY, provider);
+    }
+
+    @SubscribeEvent
+    public static void onAttachLevelCapabilities(AttachCapabilitiesEvent<Level> event) {
+        Level level = event.getObject();
+
+        VillagesProvider provider = new VillagesProvider();
+
+        provider.getCapability(VILLAGES_CAPABILITY, null)
+            .ifPresent(cap -> {
+                if (cap instanceof VillagesCapability impl) {
+                    impl.setOwnerLevel(level);
+                }
+            });
+
+        event.addCapability(VILLAGES_CAPABILITY_KEY, provider);
     }
 
     private static boolean containsTownHall(LevelChunk chunk) {

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
@@ -51,10 +51,6 @@ public class VillagesCapability implements IVillagesCapability {
         UUID villageId = UUID.randomUUID();
         VillageData newVillage = new VillageData(villageId, townHallPos, villageName, squadius);
 
-        if (!canClaimChunk(townHallPos, null)) {
-            return null;
-        }
-
         for (VillageData existingVillage : villages.values()) {
             if (existingVillage.overlaps(newVillage)) {
                 return null;

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
@@ -1,0 +1,148 @@
+package org.sosly.villageworks.capability.villages;
+
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.data.VillageData;
+
+import java.lang.ref.WeakReference;
+import java.util.*;
+
+public class VillagesCapability implements IVillagesCapability {
+
+    private final Map<UUID, VillageData> villages;
+    private final Map<String, UUID> villagesByName;
+    private WeakReference<Level> ownerLevel;
+
+    public VillagesCapability() {
+        this.villages = new HashMap<>();
+        this.villagesByName = new HashMap<>();
+        this.ownerLevel = new WeakReference<>(null);
+    }
+
+    @Override
+    public VillageData getVillageAt(ChunkPos pos) {
+        if (pos == null) {
+            return null;
+        }
+
+        for (VillageData village : villages.values()) {
+            if (village.containsChunk(pos)) {
+                return village;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public UUID createVillage(ChunkPos townHallPos, String villageName, int squadius) {
+        if (townHallPos == null || villageName == null || villageName.trim().isEmpty()) {
+            return null;
+        }
+
+        if (squadius < 1) {
+            return null;
+        }
+
+        if (villagesByName.containsKey(villageName)) {
+            return null;
+        }
+
+        UUID villageId = UUID.randomUUID();
+        VillageData newVillage = new VillageData(villageId, townHallPos, villageName, squadius);
+
+        if (!canClaimChunk(townHallPos, null)) {
+            return null;
+        }
+
+        for (VillageData existingVillage : villages.values()) {
+            if (existingVillage.overlaps(newVillage)) {
+                return null;
+            }
+        }
+
+        villages.put(villageId, newVillage);
+        villagesByName.put(villageName, villageId);
+        markDirty();
+
+        return villageId;
+    }
+
+    @Override
+    public boolean removeVillage(UUID villageId) {
+        if (villageId == null) {
+            return false;
+        }
+
+        VillageData village = villages.remove(villageId);
+        if (village == null) {
+            return false;
+        }
+
+        villagesByName.remove(village.getVillageName());
+        markDirty();
+        return true;
+    }
+
+    @Override
+    public boolean canClaimChunk(ChunkPos pos, UUID excludeVillageId) {
+        if (pos == null) {
+            return false;
+        }
+
+        for (VillageData village : villages.values()) {
+            if (excludeVillageId != null && village.getVillageId().equals(excludeVillageId)) {
+                continue;
+            }
+
+            if (village.containsChunk(pos)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public Collection<VillageData> getVillages() {
+        return new ArrayList<>(villages.values());
+    }
+
+    @Override
+    public VillageData getVillageById(UUID villageId) {
+        if (villageId == null) {
+            return null;
+        }
+        return villages.get(villageId);
+    }
+
+    @Override
+    public VillageData getVillageByName(String villageName) {
+        if (villageName == null || villageName.trim().isEmpty()) {
+            return null;
+        }
+
+        UUID villageId = villagesByName.get(villageName);
+        if (villageId == null) {
+            return null;
+        }
+
+        return villages.get(villageId);
+    }
+
+    public void setOwnerLevel(Level level) {
+        this.ownerLevel = new WeakReference<>(level);
+    }
+
+    private void markDirty() {
+        // Level capabilities are automatically saved
+    }
+
+    public void loadVillage(VillageData village) {
+        if (village == null) {
+            return;
+        }
+
+        villages.put(village.getVillageId(), village);
+        villagesByName.put(village.getVillageName(), village.getVillageId());
+    }
+}

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesProvider.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesProvider.java
@@ -1,0 +1,68 @@
+package org.sosly.villageworks.capability.villages;
+
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.LazyOptional;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.VillageData;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class VillagesProvider implements ICapabilitySerializable<CompoundTag> {
+
+    private final VillagesCapability capability;
+    private final LazyOptional<IVillagesCapability> lazyOptional;
+
+    public VillagesProvider() {
+        this.capability = new VillagesCapability();
+        this.lazyOptional = LazyOptional.of(() -> capability);
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+        if (cap == Capabilities.VILLAGES_CAPABILITY) {
+            return lazyOptional.cast();
+        }
+        return LazyOptional.empty();
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+
+        ListTag villageList = new ListTag();
+        for (VillageData village : capability.getVillages()) {
+            villageList.add(village.serializeNBT());
+        }
+        tag.put("Villages", villageList);
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        if (!tag.contains("Villages", Tag.TAG_LIST)) {
+            return;
+        }
+
+        ListTag villageList = tag.getList("Villages", Tag.TAG_COMPOUND);
+        for (int i = 0; i < villageList.size(); i++) {
+            CompoundTag villageTag = villageList.getCompound(i);
+            VillageData village = VillageData.deserializeNBT(villageTag);
+            if (village != null) {
+                capability.loadVillage(village);
+            }
+        }
+    }
+
+    public void invalidate() {
+        lazyOptional.invalidate();
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/VillageCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageCommand.java
@@ -1,0 +1,265 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.VillageData;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public class VillageCommand {
+
+    private static final int DEFAULT_SQUADIUS = 3;
+    private static final int MIN_SQUADIUS = 1;
+    private static final int MAX_SQUADIUS = 16;
+
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("village")
+            .then(Commands.literal("create")
+                .then(Commands.argument("name", StringArgumentType.string())
+                    .executes(ctx -> createVillage(ctx, DEFAULT_SQUADIUS))
+                    .then(Commands.argument("squadius", IntegerArgumentType.integer(MIN_SQUADIUS, MAX_SQUADIUS))
+                        .executes(ctx -> createVillage(ctx, IntegerArgumentType.getInteger(ctx, "squadius"))))))
+            .then(Commands.literal("remove")
+                .then(Commands.argument("name", StringArgumentType.string())
+                    .executes(VillageCommand::removeVillage)))
+            .then(Commands.literal("list")
+                .executes(VillageCommand::listVillages))
+            .then(Commands.literal("info")
+                .executes(VillageCommand::showVillageInfo)
+                .then(Commands.argument("village", StringArgumentType.string())
+                    .executes(VillageCommand::showVillageInfoByName))));
+    }
+
+    private static int createVillage(CommandContext<CommandSourceStack> context, int squadius) {
+        try {
+            CommandSourceStack source = context.getSource();
+            Entity entity = source.getEntity();
+            if (entity == null) {
+                source.sendFailure(Component.literal("Command must be executed by an entity"));
+                return 0;
+            }
+
+            String villageName = StringArgumentType.getString(context, "name");
+            if (villageName.trim().isEmpty()) {
+                source.sendFailure(Component.literal("Village name cannot be empty"));
+                return 0;
+            }
+
+            ServerLevel level = source.getLevel();
+            BlockPos pos = entity.blockPosition();
+            ChunkPos chunkPos = new ChunkPos(pos);
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    if (manager.getVillageByName(villageName) != null) {
+                        source.sendFailure(Component.literal("Village '" + villageName + "' already exists"));
+                        return 0;
+                    }
+
+                    if (!manager.canClaimChunk(chunkPos, null)) {
+                        source.sendFailure(Component.literal("Cannot create village here - overlaps with existing village"));
+                        return 0;
+                    }
+
+                    UUID villageId = manager.createVillage(chunkPos, villageName, squadius);
+                    if (villageId == null) {
+                        source.sendFailure(Component.literal("Failed to create village"));
+                        return 0;
+                    }
+
+                    source.sendSuccess(() ->
+                        Component.literal("Created village '" + villageName + "' with squadius " + squadius +
+                                        " (covers " + ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), true);
+                    return 1;
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to create village: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int removeVillage(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            String villageName = StringArgumentType.getString(context, "name");
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageByName(villageName);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village '" + villageName + "' not found"));
+                        return 0;
+                    }
+
+                    if (manager.removeVillage(village.getVillageId())) {
+                        source.sendSuccess(() ->
+                            Component.literal("Removed village '" + villageName + "'"), true);
+                        return 1;
+                    } else {
+                        source.sendFailure(Component.literal("Failed to remove village '" + villageName + "'"));
+                        return 0;
+                    }
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to remove village: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int listVillages(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    Collection<VillageData> villages = manager.getVillages();
+
+                    if (villages.isEmpty()) {
+                        source.sendSuccess(() ->
+                            Component.literal("No villages found in this dimension"), false);
+                        return 1;
+                    }
+
+                    source.sendSuccess(() ->
+                        Component.literal("Villages in " + level.dimension().location() + ":"), false);
+
+                    for (VillageData village : villages) {
+                        ChunkPos pos = village.getTownHallPos();
+                        source.sendSuccess(() ->
+                            Component.literal("- " + village.getVillageName() +
+                                            " at chunk (" + pos.x + ", " + pos.z + ") " +
+                                            "squadius " + village.getSquadius()), false);
+                    }
+
+                    return villages.size();
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to list villages: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int showVillageInfo(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            Entity entity = source.getEntity();
+            if (entity == null) {
+                source.sendFailure(Component.literal("Command must be executed by an entity"));
+                return 0;
+            }
+
+            ServerLevel level = source.getLevel();
+            BlockPos pos = entity.blockPosition();
+            ChunkPos chunkPos = new ChunkPos(pos);
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageAt(chunkPos);
+
+                    if (village == null) {
+                        source.sendSuccess(() ->
+                            Component.literal("No village at this location"), false);
+                        return 1;
+                    }
+
+                    ChunkPos townHall = village.getTownHallPos();
+                    int squadius = village.getSquadius();
+                    int minX = townHall.x - squadius;
+                    int maxX = townHall.x + squadius;
+                    int minZ = townHall.z - squadius;
+                    int maxZ = townHall.z + squadius;
+
+                    source.sendSuccess(() ->
+                        Component.literal("Village: " + village.getVillageName()), false);
+                    source.sendSuccess(() ->
+                        Component.literal("UUID: " + village.getVillageId().toString()), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Town Hall: chunk (" + townHall.x + ", " + townHall.z + ")"), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Squadius: " + squadius + " (covers " +
+                                        ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
+
+                    return 1;
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to show village info: " + e.getMessage()));
+            return 0;
+        }
+    }
+    
+    private static int showVillageInfoByName(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            String villageIdentifier = StringArgumentType.getString(context, "village");
+            ServerLevel level = source.getLevel();
+            
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village;
+                    
+                    try {
+                        UUID villageId = UUID.fromString(villageIdentifier);
+                        village = manager.getVillageById(villageId);
+                    } catch (IllegalArgumentException e) {
+                        village = manager.getVillageByName(villageIdentifier);
+                    }
+                    
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village '" + villageIdentifier + "' not found"));
+                        return 0;
+                    }
+                    
+                    final VillageData finalVillage = village;
+                    
+                    ChunkPos townHall = finalVillage.getTownHallPos();
+                    int squadius = finalVillage.getSquadius();
+                    int minX = townHall.x - squadius;
+                    int maxX = townHall.x + squadius;
+                    int minZ = townHall.z - squadius;
+                    int maxZ = townHall.z + squadius;
+                    
+                    source.sendSuccess(() ->
+                        Component.literal("Village: " + finalVillage.getVillageName()), false);
+                    source.sendSuccess(() ->
+                        Component.literal("UUID: " + finalVillage.getVillageId().toString()), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Town Hall: chunk (" + townHall.x + ", " + townHall.z + ")"), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Squadius: " + squadius + " (covers " +
+                                        ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
+                    source.sendSuccess(() ->
+                        Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
+                    
+                    return 1;
+                })
+                .orElse(0);
+                
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to show village info: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/VillageCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageCommand.java
@@ -62,16 +62,6 @@ public class VillageCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    if (manager.getVillageByName(villageName) != null) {
-                        source.sendFailure(Component.literal("Village '" + villageName + "' already exists"));
-                        return 0;
-                    }
-
-                    if (!manager.canClaimChunk(chunkPos, null)) {
-                        source.sendFailure(Component.literal("Cannot create village here - overlaps with existing village"));
-                        return 0;
-                    }
-
                     UUID villageId = manager.createVillage(chunkPos, villageName, squadius);
                     if (villageId == null) {
                         source.sendFailure(Component.literal("Failed to create village"));
@@ -232,19 +222,19 @@ public class VillageCommand {
                         return 0;
                     }
                     
-                    final VillageData finalVillage = village;
+                    final VillageData villageData = village;
                     
-                    ChunkPos townHall = finalVillage.getTownHallPos();
-                    int squadius = finalVillage.getSquadius();
+                    ChunkPos townHall = villageData.getTownHallPos();
+                    int squadius = villageData.getSquadius();
                     int minX = townHall.x - squadius;
                     int maxX = townHall.x + squadius;
                     int minZ = townHall.z - squadius;
                     int maxZ = townHall.z + squadius;
                     
                     source.sendSuccess(() ->
-                        Component.literal("Village: " + finalVillage.getVillageName()), false);
+                        Component.literal("Village: " + villageData.getVillageName()), false);
                     source.sendSuccess(() ->
-                        Component.literal("UUID: " + finalVillage.getVillageId().toString()), false);
+                        Component.literal("UUID: " + villageData.getVillageId().toString()), false);
                     source.sendSuccess(() ->
                         Component.literal("Town Hall: chunk (" + townHall.x + ", " + townHall.z + ")"), false);
                     source.sendSuccess(() ->

--- a/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
@@ -13,6 +13,7 @@ public class VillageWorksCommand {
         AssignCommand.register(vwCommand);
         ExhaustCommand.register(vwCommand);
         HungerCommand.register(vwCommand);
+        VillageCommand.register(vwCommand);
 
         dispatcher.register(vwCommand);
     }

--- a/src/main/java/org/sosly/villageworks/data/VillageData.java
+++ b/src/main/java/org/sosly/villageworks/data/VillageData.java
@@ -1,0 +1,115 @@
+package org.sosly.villageworks.data;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.ChunkPos;
+
+import java.util.UUID;
+
+public class VillageData {
+    
+    private final UUID villageId;
+    private final ChunkPos townHallPos;
+    private final int squadius;
+    private final String villageName;
+    
+    public VillageData(UUID villageId, ChunkPos townHallPos, String villageName, int squadius) {
+        this.villageId = villageId;
+        this.townHallPos = townHallPos;
+        this.villageName = villageName;
+        this.squadius = squadius;
+    }
+    
+    public UUID getVillageId() {
+        return villageId;
+    }
+    
+    public ChunkPos getTownHallPos() {
+        return townHallPos;
+    }
+    
+    public String getVillageName() {
+        return villageName;
+    }
+    
+    public int getSquadius() {
+        return squadius;
+    }
+    
+    public boolean containsChunk(ChunkPos pos) {
+        if (pos == null) {
+            return false;
+        }
+        
+        int centerX = townHallPos.x;
+        int centerZ = townHallPos.z;
+        
+        return pos.x >= centerX - squadius &&
+               pos.x <= centerX + squadius &&
+               pos.z >= centerZ - squadius &&
+               pos.z <= centerZ + squadius;
+    }
+    
+    public boolean overlaps(VillageData other) {
+        if (other == null) {
+            return false;
+        }
+        
+        int thisMinX = townHallPos.x - squadius;
+        int thisMaxX = townHallPos.x + squadius;
+        int thisMinZ = townHallPos.z - squadius;
+        int thisMaxZ = townHallPos.z + squadius;
+        
+        int otherMinX = other.townHallPos.x - other.squadius;
+        int otherMaxX = other.townHallPos.x + other.squadius;
+        int otherMinZ = other.townHallPos.z - other.squadius;
+        int otherMaxZ = other.townHallPos.z + other.squadius;
+        
+        return thisMinX <= otherMaxX && thisMaxX >= otherMinX &&
+               thisMinZ <= otherMaxZ && thisMaxZ >= otherMinZ;
+    }
+    
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("VillageId", villageId.toString());
+        tag.putLong("TownHallPos", townHallPos.toLong());
+        tag.putString("VillageName", villageName);
+        tag.putInt("Squadius", squadius);
+        return tag;
+    }
+    
+    public static VillageData deserializeNBT(CompoundTag tag) {
+        if (!tag.contains("VillageId") || !tag.contains("TownHallPos") ||
+            !tag.contains("VillageName") || !tag.contains("Squadius")) {
+            return null;
+        }
+        
+        try {
+            UUID villageId = UUID.fromString(tag.getString("VillageId"));
+            ChunkPos townHallPos = new ChunkPos(tag.getLong("TownHallPos"));
+            String villageName = tag.getString("VillageName");
+            int squadius = tag.getInt("Squadius");
+            
+            return new VillageData(villageId, townHallPos, villageName, squadius);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        
+        VillageData other = (VillageData) obj;
+        return villageId.equals(other.villageId);
+    }
+    
+    @Override
+    public int hashCode() {
+        return villageId.hashCode();
+    }
+}


### PR DESCRIPTION
# Add village management system with admin commands
Implements dimension-wide village management with CRUD operations, boundary calculations, and admin commands for server administrators.

## Changes
- Added IVillagesCapability interface for village management API
- Implemented VillagesCapability with village creation, removal, and lookup
- Created VillageData class with squadius-based square boundary calculations
- Added VillagesProvider for NBT serialization and Level capability attachment
- Implemented VillageCommand with create/remove/list/info subcommands
- Added village lookup by name or UUID in info command
- Integrated overlap prevention and squadius validation (1-16 range)
- Updated CHANGELOG.md with new admin commands

## Related Issues
Resolves #16

## Implementation Notes
Villages use "squadius" (square radius) for boundary calculations, creating square areas around town hall chunks. Level capabilities handle automatic persistence without manual markDirty calls. All commands require op level 2 for admin-only access. Villages persist across world saves and prevent overlapping territorial claims.

## Breaking Changes
None