### PR TITLE
Implement zone shapes and commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Town Hall block that automatically creates a village when placed
 - Villages are automatically named after the player who places the Town Hall
 - Villages require a minimum distance of 30 chunks between each other
+- Zone system for defining functional areas within villages
+- Four zone shapes: AABB (rectangular), Radius (circular), BlockPos (single block), and Path (connected points)
+- Zone types: STORAGE (finds chests/barrels), TOWNHALL (finds town hall blocks), HOME (finds beds), NONE (no POI scanning)
+- `/vw zone create` commands for all zone shapes with tab completion for zone types
+- `/vw zone delete <zoneUUID>` command to remove zones with UUID tab completion
+- `/vw zone rename <zoneUUID> <name>` command to rename zones
+- `/vw zone info <zoneUUID>` command showing zone bounds, type, and discovered POIs with block names
+- `/vw zone list` command to display all zones in a village
+- `/vw zone path add/clear` commands for managing path zone points
+- Tab completion for village UUIDs and zone UUIDs in all zone commands
+- Support for relative coordinates (`~ ~ ~`) in zone creation commands
+- Automatic POI (Point of Interest) detection and caching within zones

--- a/src/main/java/org/sosly/villageworks/VillageWorks.java
+++ b/src/main/java/org/sosly/villageworks/VillageWorks.java
@@ -1,6 +1,7 @@
 package org.sosly.villageworks;
 
 import com.mojang.logging.LogUtils;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;

--- a/src/main/java/org/sosly/villageworks/api/data/IVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/api/data/IVillageZone.java
@@ -2,6 +2,7 @@ package org.sosly.villageworks.api.data;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +39,11 @@ public interface IVillageZone {
      * @return Functional type determining zone behavior and POI scanning
      */
     ZoneType getType();
+    
+    /**
+     * @return The level this zone exists in
+     */
+    Level getLevel();
     
     /**
      * Returns type-specific points of interest within this zone.

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
@@ -39,7 +39,50 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public List<IVillageZone> getZones() {
-        return new ArrayList<>(zones);
+        return new ModifiableZoneList(zones, this::markDirty);
+    }
+    
+    private static class ModifiableZoneList extends ArrayList<IVillageZone> {
+        private final Runnable onModify;
+        
+        public ModifiableZoneList(List<IVillageZone> zones, Runnable onModify) {
+            super(zones);
+            this.onModify = onModify;
+        }
+        
+        @Override
+        public IVillageZone set(int index, IVillageZone element) {
+            IVillageZone result = super.set(index, element);
+            onModify.run();
+            return result;
+        }
+        
+        @Override
+        public boolean add(IVillageZone zone) {
+            boolean result = super.add(zone);
+            if (result) onModify.run();
+            return result;
+        }
+        
+        @Override
+        public void add(int index, IVillageZone element) {
+            super.add(index, element);
+            onModify.run();
+        }
+        
+        @Override
+        public IVillageZone remove(int index) {
+            IVillageZone result = super.remove(index);
+            onModify.run();
+            return result;
+        }
+        
+        @Override
+        public boolean remove(Object o) {
+            boolean result = super.remove(o);
+            if (result) onModify.run();
+            return result;
+        }
     }
     
     @Override
@@ -50,6 +93,14 @@ public class VillageCapability implements IVillageCapability {
         
         zones.add(zone);
         markDirty();
+    }
+    
+    public void addZoneWithoutDirty(IVillageZone zone) {
+        if (zone == null) {
+            return;
+        }
+        
+        zones.add(zone);
     }
     
     @Override
@@ -145,7 +196,7 @@ public class VillageCapability implements IVillageCapability {
         this.ownerChunk = new WeakReference<>(chunk);
     }
     
-    private void markDirty() {
+    public void markDirty() {
         LevelChunk chunk = ownerChunk.get();
         if (chunk != null) {
             chunk.setUnsaved(true);

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import org.sosly.villageworks.api.capability.IVillageCapability;
 import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.zones.ZoneFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -98,8 +99,17 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
             }
         }
 
-        // TODO: Deserialize zones when zone factory/registry is implemented
-        // Need a way to create zone instances from ZoneType enum
+        // Deserialize zones
+        if (tag.contains("Zones", Tag.TAG_LIST)) {
+            ListTag zoneList = tag.getList("Zones", Tag.TAG_COMPOUND);
+            for (int i = 0; i < zoneList.size(); i++) {
+                CompoundTag zoneTag = zoneList.getCompound(i);
+                var zone = ZoneFactory.deserializeFromNBT(zoneTag);
+                if (zone != null) {
+                    capability.addZoneWithoutDirty(zone);
+                }
+            }
+        }
     }
 
     public void invalidate() {

--- a/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
@@ -14,6 +14,7 @@ public class VillageWorksCommand {
         ExhaustCommand.register(vwCommand);
         HungerCommand.register(vwCommand);
         VillageCommand.register(vwCommand);
+        ZoneCommand.register(vwCommand);
 
         dispatcher.register(vwCommand);
     }

--- a/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
@@ -119,7 +119,7 @@ public class ZoneCommand {
 
             return createZoneInVillage(source, villageId, level -> {
                 int nextId = getNextZoneId(level, villageId);
-                return ZoneFactory.createAABBZone(zoneType, nextId, name, bounds);
+                return ZoneFactory.createAABBZone(zoneType, nextId, name, bounds, level);
             });
 
         } catch (Exception e) {
@@ -148,7 +148,7 @@ public class ZoneCommand {
 
             return createZoneInVillage(source, villageId, level -> {
                 int nextId = getNextZoneId(level, villageId);
-                return ZoneFactory.createRadiusZone(zoneType, nextId, name, center, radius);
+                return ZoneFactory.createRadiusZone(zoneType, nextId, name, center, radius, level);
             });
 
         } catch (Exception e) {
@@ -176,7 +176,7 @@ public class ZoneCommand {
 
             return createZoneInVillage(source, villageId, level -> {
                 int nextId = getNextZoneId(level, villageId);
-                return ZoneFactory.createBlockPosZone(zoneType, nextId, name, pos);
+                return ZoneFactory.createBlockPosZone(zoneType, nextId, name, pos, level);
             });
 
         } catch (Exception e) {
@@ -202,7 +202,7 @@ public class ZoneCommand {
 
             return createZoneInVillage(source, villageId, level -> {
                 int nextId = getNextZoneId(level, villageId);
-                return ZoneFactory.createPathZone(zoneType, nextId, name, new ArrayList<>());
+                return ZoneFactory.createPathZone(zoneType, nextId, name, new ArrayList<>(), level);
             });
 
         } catch (Exception e) {
@@ -610,16 +610,6 @@ public class ZoneCommand {
     }
     
     private static void showZonePOIs(CommandSourceStack source, IVillageZone zone, ServerLevel level) {
-        if (zone instanceof org.sosly.villageworks.data.zones.AABBVillageZone aabbZone) {
-            aabbZone.rescanPOIs(level);
-        } else if (zone instanceof org.sosly.villageworks.data.zones.RadiusVillageZone radiusZone) {
-            radiusZone.rescanPOIs(level);
-        } else if (zone instanceof org.sosly.villageworks.data.zones.BlockPosVillageZone blockPosZone) {
-            blockPosZone.rescanPOIs(level);
-        } else if (zone instanceof org.sosly.villageworks.data.zones.PathVillageZone pathZone) {
-            pathZone.rescanPOIs(level);
-        }
-        
         var pois = zone.getPOIs();
         if (pois.isEmpty()) {
             source.sendSuccess(() ->

--- a/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
@@ -1,0 +1,703 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.phys.AABB;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneType;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
+import org.sosly.villageworks.command.arguments.ZoneTypeArgument;
+import org.sosly.villageworks.command.arguments.ZoneUUIDArgument;
+import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.zones.PathVillageZone;
+import org.sosly.villageworks.data.zones.ZoneFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ZoneCommand {
+
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("zone")
+            .then(Commands.argument("villageUUID", VillageUUIDArgument.villageUUID())
+                .suggests((context, builder) -> VillageUUIDArgument.suggest(context, builder))
+                .then(Commands.literal("create")
+                    .then(Commands.literal("aabb")
+                        .then(Commands.argument("pos1", BlockPosArgument.blockPos())
+                            .then(Commands.argument("pos2", BlockPosArgument.blockPos())
+                                .then(Commands.argument("type", ZoneTypeArgument.zoneType())
+                                    .suggests((context, builder) -> ZoneTypeArgument.suggest(context, builder))
+                                    .executes(ZoneCommand::createAABBZone)
+                                    .then(Commands.argument("name", StringArgumentType.string())
+                                        .executes(ZoneCommand::createAABBZoneWithName))))))
+                    .then(Commands.literal("radius")
+                        .then(Commands.argument("center", BlockPosArgument.blockPos())
+                            .then(Commands.argument("radius", IntegerArgumentType.integer(1))
+                                .then(Commands.argument("type", ZoneTypeArgument.zoneType())
+                                    .suggests((context, builder) -> ZoneTypeArgument.suggest(context, builder))
+                                    .executes(ZoneCommand::createRadiusZone)
+                                    .then(Commands.argument("name", StringArgumentType.string())
+                                        .executes(ZoneCommand::createRadiusZoneWithName))))))
+                    .then(Commands.literal("blockpos")
+                        .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                            .then(Commands.argument("type", ZoneTypeArgument.zoneType())
+                                .suggests((context, builder) -> ZoneTypeArgument.suggest(context, builder))
+                                .executes(ZoneCommand::createBlockPosZone)
+                                .then(Commands.argument("name", StringArgumentType.string())
+                                    .executes(ZoneCommand::createBlockPosZoneWithName)))))
+                    .then(Commands.literal("path")
+                        .then(Commands.argument("type", ZoneTypeArgument.zoneType())
+                            .suggests((context, builder) -> ZoneTypeArgument.suggest(context, builder))
+                            .executes(ZoneCommand::createPathZone)
+                            .then(Commands.argument("name", StringArgumentType.string())
+                                .executes(ZoneCommand::createPathZoneWithName)))))
+                .then(Commands.literal("delete")
+                    .then(Commands.argument("zoneUUID", ZoneUUIDArgument.zoneUUID())
+                        .suggests((context, builder) -> ZoneUUIDArgument.suggest(context, builder))
+                        .executes(ZoneCommand::deleteZone)))
+                .then(Commands.literal("type")
+                    .then(Commands.argument("zoneUUID", ZoneUUIDArgument.zoneUUID())
+                        .suggests((context, builder) -> ZoneUUIDArgument.suggest(context, builder))
+                        .then(Commands.argument("zonetype", ZoneTypeArgument.zoneType())
+                            .suggests((context, builder) -> ZoneTypeArgument.suggest(context, builder))
+                            .executes(ZoneCommand::changeZoneType))))
+                .then(Commands.literal("rename")
+                    .then(Commands.argument("zoneUUID", ZoneUUIDArgument.zoneUUID())
+                        .suggests((context, builder) -> ZoneUUIDArgument.suggest(context, builder))
+                        .then(Commands.argument("name", StringArgumentType.string())
+                            .executes(ZoneCommand::renameZone))))
+                .then(Commands.literal("info")
+                    .then(Commands.argument("zoneUUID", ZoneUUIDArgument.zoneUUID())
+                        .suggests((context, builder) -> ZoneUUIDArgument.suggest(context, builder))
+                        .executes(ZoneCommand::showZoneInfo)))
+                .then(Commands.literal("list")
+                    .executes(ZoneCommand::listZones))
+                .then(Commands.literal("path")
+                    .then(Commands.argument("zoneUUID", ZoneUUIDArgument.zoneUUID())
+                        .suggests((context, builder) -> ZoneUUIDArgument.suggest(context, builder))
+                        .then(Commands.literal("add")
+                            .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                                .executes(ZoneCommand::addPathPoint)))
+                        .then(Commands.literal("clear")
+                            .executes(ZoneCommand::clearPath))))));
+    }
+
+    private static int createAABBZone(CommandContext<CommandSourceStack> context) {
+        return createAABBZoneInternal(context, null);
+    }
+
+    private static int createAABBZoneWithName(CommandContext<CommandSourceStack> context) {
+        String name = StringArgumentType.getString(context, "name");
+        return createAABBZoneInternal(context, name);
+    }
+
+    private static int createAABBZoneInternal(CommandContext<CommandSourceStack> context, String name) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
+
+            BlockPos pos1 = BlockPosArgument.getBlockPos(context, "pos1");
+            BlockPos pos2 = BlockPosArgument.getBlockPos(context, "pos2");
+
+            AABB bounds = new AABB(
+                Math.min(pos1.getX(), pos2.getX()), Math.min(pos1.getY(), pos2.getY()), Math.min(pos1.getZ(), pos2.getZ()),
+                Math.max(pos1.getX(), pos2.getX()), Math.max(pos1.getY(), pos2.getY()), Math.max(pos1.getZ(), pos2.getZ())
+            );
+
+            return createZoneInVillage(source, villageId, level -> {
+                int nextId = getNextZoneId(level, villageId);
+                return ZoneFactory.createAABBZone(zoneType, nextId, name, bounds);
+            });
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to create AABB zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int createRadiusZone(CommandContext<CommandSourceStack> context) {
+        return createRadiusZoneInternal(context, null);
+    }
+
+    private static int createRadiusZoneWithName(CommandContext<CommandSourceStack> context) {
+        String name = StringArgumentType.getString(context, "name");
+        return createRadiusZoneInternal(context, name);
+    }
+
+    private static int createRadiusZoneInternal(CommandContext<CommandSourceStack> context, String name) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
+
+            BlockPos center = BlockPosArgument.getBlockPos(context, "center");
+            int radius = IntegerArgumentType.getInteger(context, "radius");
+
+            return createZoneInVillage(source, villageId, level -> {
+                int nextId = getNextZoneId(level, villageId);
+                return ZoneFactory.createRadiusZone(zoneType, nextId, name, center, radius);
+            });
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to create radius zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int createBlockPosZone(CommandContext<CommandSourceStack> context) {
+        return createBlockPosZoneInternal(context, null);
+    }
+
+    private static int createBlockPosZoneWithName(CommandContext<CommandSourceStack> context) {
+        String name = StringArgumentType.getString(context, "name");
+        return createBlockPosZoneInternal(context, name);
+    }
+
+    private static int createBlockPosZoneInternal(CommandContext<CommandSourceStack> context, String name) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
+
+            BlockPos pos = BlockPosArgument.getBlockPos(context, "pos");
+
+            return createZoneInVillage(source, villageId, level -> {
+                int nextId = getNextZoneId(level, villageId);
+                return ZoneFactory.createBlockPosZone(zoneType, nextId, name, pos);
+            });
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to create blockpos zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int createPathZone(CommandContext<CommandSourceStack> context) {
+        return createPathZoneInternal(context, null);
+    }
+
+    private static int createPathZoneWithName(CommandContext<CommandSourceStack> context) {
+        String name = StringArgumentType.getString(context, "name");
+        return createPathZoneInternal(context, name);
+    }
+
+    private static int createPathZoneInternal(CommandContext<CommandSourceStack> context, String name) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
+
+            return createZoneInVillage(source, villageId, level -> {
+                int nextId = getNextZoneId(level, villageId);
+                return ZoneFactory.createPathZone(zoneType, nextId, name, new ArrayList<>());
+            });
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to create path zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int deleteZone(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            UUID zoneId = ZoneUUIDArgument.getZoneUUID(context, "zoneUUID");
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            boolean removed = villageCapability.removeZone(zoneId);
+                            if (removed) {
+                                source.sendSuccess(() ->
+                                    Component.literal("Deleted zone " + zoneId), true);
+                                return 1;
+                            } else {
+                                source.sendFailure(Component.literal("Zone not found in village"));
+                                return 0;
+                            }
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to delete zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int changeZoneType(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            UUID zoneId = ZoneUUIDArgument.getZoneUUID(context, "zoneUUID");
+            ZoneType newZoneType = ZoneTypeArgument.getZoneType(context, "zonetype");
+            
+            source.sendFailure(Component.literal("Zone type changing not implemented yet"));
+            return 0;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to change zone type: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int renameZone(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            String villageUUIDStr = StringArgumentType.getString(context, "villageUUID");
+            String zoneUUIDStr = StringArgumentType.getString(context, "zoneUUID");
+            String newName = StringArgumentType.getString(context, "name");
+
+            UUID villageId;
+            UUID zoneId;
+            try {
+                villageId = UUID.fromString(villageUUIDStr);
+                zoneId = UUID.fromString(zoneUUIDStr);
+            } catch (IllegalArgumentException e) {
+                source.sendFailure(Component.literal("Invalid UUID format"));
+                return 0;
+            }
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+                            for (IVillageZone zone : zones) {
+                                if (zone.getUUID().equals(zoneId)) {
+                                    zone.setName(newName);
+                                    source.sendSuccess(() ->
+                                        Component.literal("Renamed zone to '" + newName + "'"), true);
+                                    return 1;
+                                }
+                            }
+                            source.sendFailure(Component.literal("Zone not found in village"));
+                            return 0;
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to rename zone: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int showZoneInfo(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            UUID zoneId = ZoneUUIDArgument.getZoneUUID(context, "zoneUUID");
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+                            for (IVillageZone zone : zones) {
+                                if (zone.getUUID().equals(zoneId)) {
+                                    source.sendSuccess(() ->
+                                        Component.literal("Zone: " + zone.getName()), false);
+                                    source.sendSuccess(() ->
+                                        Component.literal("UUID: " + zone.getUUID()), false);
+                                    source.sendSuccess(() ->
+                                        Component.literal("Type: " + zone.getType()), false);
+                                    source.sendSuccess(() ->
+                                        Component.literal("Shape: " + zone.getShape()), false);
+                                    
+                                    showZoneBounds(source, zone);
+                                    showZonePOIs(source, zone, level);
+                                    
+                                    return 1;
+                                }
+                            }
+                            source.sendFailure(Component.literal("Zone not found in village"));
+                            return 0;
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to show zone info: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int listZones(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+
+                            if (zones.isEmpty()) {
+                                source.sendSuccess(() ->
+                                    Component.literal("No zones found in village"), false);
+                                return 1;
+                            }
+
+                            source.sendSuccess(() ->
+                                Component.literal("Zones in " + village.getVillageName() + ":"), false);
+
+                            for (IVillageZone zone : zones) {
+                                source.sendSuccess(() ->
+                                    Component.literal("- " + zone.getName() + " (" + zone.getType() + ", " + zone.getShape() + ") UUID: " + zone.getUUID()), false);
+                            }
+
+                            return zones.size();
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to list zones: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int addPathPoint(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            String villageUUIDStr = StringArgumentType.getString(context, "villageUUID");
+            String zoneUUIDStr = StringArgumentType.getString(context, "zoneUUID");
+            BlockPos pos = BlockPosArgument.getBlockPos(context, "pos");
+
+            UUID villageId;
+            UUID zoneId;
+            try {
+                villageId = UUID.fromString(villageUUIDStr);
+                zoneId = UUID.fromString(zoneUUIDStr);
+            } catch (IllegalArgumentException e) {
+                source.sendFailure(Component.literal("Invalid UUID format"));
+                return 0;
+            }
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+                            for (IVillageZone zone : zones) {
+                                if (zone.getUUID().equals(zoneId) && zone instanceof PathVillageZone pathZone) {
+                                    pathZone.addPoint(pos);
+                                    source.sendSuccess(() ->
+                                        Component.literal("Added point " + pos.toShortString() + " to path zone"), true);
+                                    return 1;
+                                }
+                            }
+                            source.sendFailure(Component.literal("Path zone not found in village"));
+                            return 0;
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to add path point: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int clearPath(CommandContext<CommandSourceStack> context) {
+        try {
+            CommandSourceStack source = context.getSource();
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            UUID zoneId = ZoneUUIDArgument.getZoneUUID(context, "zoneUUID");
+
+            ServerLevel level = source.getLevel();
+
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        source.sendFailure(Component.literal("Village not found"));
+                        return 0;
+                    }
+
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+                            for (IVillageZone zone : zones) {
+                                if (zone.getUUID().equals(zoneId) && zone instanceof PathVillageZone pathZone) {
+                                    pathZone.clearPath();
+                                    source.sendSuccess(() ->
+                                        Component.literal("Cleared path zone"), true);
+                                    return 1;
+                                }
+                            }
+                            source.sendFailure(Component.literal("Path zone not found in village"));
+                            return 0;
+                        })
+                        .orElse(0);
+                })
+                .orElse(0);
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to clear path: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int createZoneInVillage(CommandSourceStack source, UUID villageId, ZoneCreator factory) {
+        ServerLevel level = source.getLevel();
+
+        return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+            .map(manager -> {
+                VillageData village = manager.getVillageById(villageId);
+                if (village == null) {
+                    source.sendFailure(Component.literal("Village not found"));
+                    return 0;
+                }
+
+                ChunkPos townHallPos = village.getTownHallPos();
+                LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                    .map(villageCapability -> {
+                        try {
+                            IVillageZone zone = factory.createZone(level);
+                            villageCapability.addZone(zone);
+
+                            source.sendSuccess(() ->
+                                Component.literal("Created zone '" + zone.getName() + "' with UUID: " + zone.getUUID()), true);
+                            return 1;
+
+                        } catch (Exception e) {
+                            source.sendFailure(Component.literal("Failed to create zone: " + e.getMessage()));
+                            return 0;
+                        }
+                    })
+                    .orElse(0);
+            })
+            .orElse(0);
+    }
+
+    private static int getNextZoneId(ServerLevel level, UUID villageId) {
+        return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+            .map(manager -> {
+                VillageData village = manager.getVillageById(villageId);
+                if (village == null) {
+                    return 1;
+                }
+
+                ChunkPos townHallPos = village.getTownHallPos();
+                LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+
+                return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                    .map(villageCapability -> {
+                        List<IVillageZone> zones = villageCapability.getZones();
+                        return zones.size() + 1;
+                    })
+                    .orElse(1);
+            })
+            .orElse(1);
+    }
+
+    private static void showZoneBounds(CommandSourceStack source, IVillageZone zone) {
+        if (zone instanceof org.sosly.villageworks.data.zones.AABBVillageZone aabbZone) {
+            var bounds = aabbZone.getAABB();
+            source.sendSuccess(() ->
+                Component.literal("Bounds: (" + (int)bounds.minX + ", " + (int)bounds.minY + ", " + (int)bounds.minZ + 
+                               ") to (" + (int)bounds.maxX + ", " + (int)bounds.maxY + ", " + (int)bounds.maxZ + ")"), false);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.RadiusVillageZone radiusZone) {
+            var center = radiusZone.getCenter();
+            source.sendSuccess(() ->
+                Component.literal("Center: " + center.toShortString() + ", Radius: " + radiusZone.getRadius()), false);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.BlockPosVillageZone blockPosZone) {
+            var pos = blockPosZone.getBlockPos();
+            source.sendSuccess(() ->
+                Component.literal("Position: " + pos.toShortString()), false);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.PathVillageZone pathZone) {
+            var path = pathZone.getPath();
+            if (path.isEmpty()) {
+                source.sendSuccess(() ->
+                    Component.literal("Path: Empty"), false);
+            } else {
+                source.sendSuccess(() ->
+                    Component.literal("Path: " + path.size() + " points"), false);
+                for (int i = 0; i < Math.min(path.size(), 5); i++) {
+                    final int index = i;
+                    source.sendSuccess(() ->
+                        Component.literal("  " + index + ": " + path.get(index).toShortString()), false);
+                }
+                if (path.size() > 5) {
+                    source.sendSuccess(() ->
+                        Component.literal("  ... and " + (path.size() - 5) + " more points"), false);
+                }
+            }
+        }
+    }
+    
+    private static void showZonePOIs(CommandSourceStack source, IVillageZone zone, ServerLevel level) {
+        if (zone instanceof org.sosly.villageworks.data.zones.AABBVillageZone aabbZone) {
+            aabbZone.rescanPOIs(level);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.RadiusVillageZone radiusZone) {
+            radiusZone.rescanPOIs(level);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.BlockPosVillageZone blockPosZone) {
+            blockPosZone.rescanPOIs(level);
+        } else if (zone instanceof org.sosly.villageworks.data.zones.PathVillageZone pathZone) {
+            pathZone.rescanPOIs(level);
+        }
+        
+        var pois = zone.getPOIs();
+        if (pois.isEmpty()) {
+            source.sendSuccess(() ->
+                Component.literal("POIs: None (zone type: " + zone.getType() + ")"), false);
+        } else {
+            var poiList = pois.get();
+            source.sendSuccess(() ->
+                Component.literal("POIs: " + poiList.size() + " found"), false);
+            for (int i = 0; i < Math.min(poiList.size(), 10); i++) {
+                final int index = i;
+                final BlockPos pos = poiList.get(index);
+                String blockName = getBlockDisplayName(level, pos);
+                source.sendSuccess(() ->
+                    Component.literal("  " + index + ": " + blockName + " at " + pos.toShortString()), false);
+            }
+            if (poiList.size() > 10) {
+                source.sendSuccess(() ->
+                    Component.literal("  ... and " + (poiList.size() - 10) + " more POIs"), false);
+            }
+        }
+    }
+    
+    private static String getBlockDisplayName(ServerLevel level, BlockPos pos) {
+        var blockState = level.getBlockState(pos);
+        var block = blockState.getBlock();
+        String blockName = block.getDescriptionId();
+        
+        // Convert from translation key to display name
+        if (blockName.startsWith("block.")) {
+            // Remove "block." prefix and convert underscores to spaces
+            String cleanName = blockName.substring(6);
+            
+            // Handle mod blocks vs vanilla blocks
+            if (cleanName.contains(".")) {
+                String[] parts = cleanName.split("\\.", 2);
+                String modId = parts[0];
+                String blockId = parts[1];
+                
+                if ("villageworks".equals(modId)) {
+                    // Special handling for our blocks
+                    return switch (blockId) {
+                        case "townhall" -> "Town Hall Block";
+                        default -> formatBlockName(blockId);
+                    };
+                } else {
+                    // Other mod blocks
+                    return formatBlockName(blockId) + " (" + modId + ")";
+                }
+            } else {
+                // Vanilla blocks
+                return switch (cleanName) {
+                    case "chest" -> "Chest";
+                    case "barrel" -> "Barrel";
+                    case "shulker_box" -> "Shulker Box";
+                    case "white_bed", "orange_bed", "magenta_bed", "light_blue_bed", 
+                         "yellow_bed", "lime_bed", "pink_bed", "gray_bed", "light_gray_bed", 
+                         "cyan_bed", "purple_bed", "blue_bed", "brown_bed", "green_bed", 
+                         "red_bed", "black_bed" -> {
+                        String color = cleanName.replace("_bed", "");
+                        yield formatBlockName(color) + " Bed";
+                    }
+                    default -> formatBlockName(cleanName);
+                };
+            }
+        }
+        
+        return blockName; // Fallback to raw translation key
+    }
+    
+    private static String formatBlockName(String name) {
+        return java.util.Arrays.stream(name.split("_"))
+            .map(word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase())
+            .reduce((a, b) -> a + " " + b)
+            .orElse(name);
+    }
+
+    @FunctionalInterface
+    private interface ZoneCreator {
+        IVillageZone createZone(ServerLevel level);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/arguments/VillageUUIDArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/VillageUUIDArgument.java
@@ -1,0 +1,55 @@
+package org.sosly.villageworks.command.arguments;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.VillageData;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class VillageUUIDArgument {
+    
+    private static final DynamicCommandExceptionType INVALID_UUID = new DynamicCommandExceptionType(
+        uuid -> Component.literal("Invalid village UUID: " + uuid)
+    );
+    
+    public static ArgumentType<String> villageUUID() {
+        return StringArgumentType.word();
+    }
+    
+    public static UUID getVillageUUID(CommandContext<CommandSourceStack> context, String name) throws CommandSyntaxException {
+        String input = StringArgumentType.getString(context, name);
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException e) {
+            throw INVALID_UUID.create(input);
+        }
+    }
+    
+    public static CompletableFuture<Suggestions> suggest(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
+        ServerLevel level = context.getSource().getLevel();
+        
+        return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+            .map(manager -> {
+                Collection<VillageData> villages = manager.getVillages();
+                Collection<String> villageUUIDs = villages.stream()
+                    .map(village -> village.getVillageId().toString())
+                    .collect(Collectors.toList());
+                
+                return SharedSuggestionProvider.suggest(villageUUIDs, builder);
+            })
+            .orElse(Suggestions.empty());
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/arguments/ZoneTypeArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/ZoneTypeArgument.java
@@ -1,0 +1,42 @@
+package org.sosly.villageworks.command.arguments;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+public class ZoneTypeArgument {
+    
+    private static final Collection<String> ZONE_TYPE_NAMES = Arrays.asList("storage", "townhall", "home", "none");
+    private static final DynamicCommandExceptionType INVALID_ZONE_TYPE = new DynamicCommandExceptionType(
+        type -> Component.literal("Invalid zone type: " + type)
+    );
+    
+    public static ArgumentType<String> zoneType() {
+        return StringArgumentType.word();
+    }
+    
+    public static ZoneType getZoneType(CommandContext<?> context, String name) throws CommandSyntaxException {
+        String input = StringArgumentType.getString(context, name);
+        try {
+            return ZoneType.valueOf(input.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw INVALID_ZONE_TYPE.create(input);
+        }
+    }
+    
+    public static CompletableFuture<Suggestions> suggest(CommandContext<?> context, SuggestionsBuilder builder) {
+        return SharedSuggestionProvider.suggest(ZONE_TYPE_NAMES, builder);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
@@ -1,0 +1,78 @@
+package org.sosly.villageworks.command.arguments;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.VillageData;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class ZoneUUIDArgument {
+    
+    private static final DynamicCommandExceptionType INVALID_UUID = new DynamicCommandExceptionType(
+        uuid -> Component.literal("Invalid zone UUID: " + uuid)
+    );
+    
+    public static ArgumentType<String> zoneUUID() {
+        return StringArgumentType.word();
+    }
+    
+    public static UUID getZoneUUID(CommandContext<CommandSourceStack> context, String name) throws CommandSyntaxException {
+        String input = StringArgumentType.getString(context, name);
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException e) {
+            throw INVALID_UUID.create(input);
+        }
+    }
+    
+    public static CompletableFuture<Suggestions> suggest(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
+        try {
+            String villageUUIDStr = StringArgumentType.getString(context, "villageUUID");
+            UUID villageId = UUID.fromString(villageUUIDStr);
+            
+            ServerLevel level = context.getSource().getLevel();
+            
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        return Suggestions.empty();
+                    }
+                    
+                    ChunkPos townHallPos = village.getTownHallPos();
+                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    
+                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
+                        .map(villageCapability -> {
+                            List<IVillageZone> zones = villageCapability.getZones();
+                            Collection<String> zoneUUIDs = zones.stream()
+                                .map(zone -> zone.getUUID().toString())
+                                .collect(Collectors.toList());
+                            
+                            return SharedSuggestionProvider.suggest(zoneUUIDs, builder);
+                        })
+                        .orElse(Suggestions.empty());
+                })
+                .orElse(Suggestions.empty());
+        } catch (Exception e) {
+            return Suggestions.empty();
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/AABBVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/AABBVillageZone.java
@@ -2,7 +2,6 @@ package org.sosly.villageworks.data.zones;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import org.sosly.villageworks.api.data.IVillageZone;
@@ -11,25 +10,22 @@ import org.sosly.villageworks.api.data.ZoneType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-public class AABBVillageZone implements IVillageZone {
+public class AABBVillageZone extends AbstractVillageZone implements IVillageZone {
 
-    private final UUID uuid;
-    private final ZoneType type;
-    private final int id;
-    private String name;
     private AABB bounds;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
+    public AABBVillageZone(UUID uuid, ZoneType type, int id, String name, AABB bounds, Level level) {
+        super(uuid, type, id, name, level);
+        this.bounds = bounds;
+    }
+
     public AABBVillageZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
-        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
-        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
-        this.id = id;
-        this.name = name;
+        super(uuid, type, id, name);
         this.bounds = bounds;
     }
 
@@ -43,36 +39,12 @@ public class AABBVillageZone implements IVillageZone {
         this.poiCacheDirty = true;
     }
 
-    @Override
-    public UUID getUUID() {
-        return uuid;
-    }
-
-    @Override
-    public String getName() {
-        if (name != null) {
-            return name;
-        }
-
-        String translationKey = "villageworks.zone." + type.name().toLowerCase();
-        String zoneName = Component.translatable(translationKey).getString();
-        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
 
     @Override
     public ZoneShape getShape() {
         return ZoneShape.AABB;
     }
 
-    @Override
-    public ZoneType getType() {
-        return type;
-    }
 
     @Override
     public boolean containsPosition(BlockPos pos) {
@@ -87,27 +59,15 @@ public class AABBVillageZone implements IVillageZone {
 
     @Override
     public Optional<List<BlockPos>> getPOIs() {
-        if (getType() == ZoneType.NONE) {
+        if (getType() == ZoneType.NONE || getLevel() == null) {
             return Optional.empty();
         }
 
         if (poiCacheDirty) {
-            rescanPOIs();
+            rescanPOIs(getLevel());
         }
 
         return Optional.of(new ArrayList<>(cachedPOIs));
-    }
-
-    private void rescanPOIs() {
-        cachedPOIs = new ArrayList<>();
-
-        if (bounds == null) {
-            poiCacheDirty = false;
-            return;
-        }
-
-        // Need level to scan - will be passed when needed
-        poiCacheDirty = false;
     }
 
     public void rescanPOIs(Level level) {
@@ -142,13 +102,7 @@ public class AABBVillageZone implements IVillageZone {
 
     @Override
     public CompoundTag serializeNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString("UUID", uuid.toString());
-        tag.putByte("Type", (byte) type.ordinal());
-        tag.putShort("Id", (short) id);
-        if (name != null) {
-            tag.putString("Name", name);
-        }
+        CompoundTag tag = super.serializeNBT();
         tag.putByte("Shape", (byte) ZoneShape.AABB.ordinal());
 
         if (bounds != null) {
@@ -167,9 +121,7 @@ public class AABBVillageZone implements IVillageZone {
 
     @Override
     public void deserializeNBT(CompoundTag tag) {
-        if (tag.contains("Name")) {
-            this.name = tag.getString("Name");
-        }
+        super.deserializeNBT(tag);
 
         if (tag.contains("Bounds")) {
             CompoundTag boundsTag = tag.getCompound("Bounds");

--- a/src/main/java/org/sosly/villageworks/data/zones/AABBVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/AABBVillageZone.java
@@ -1,0 +1,188 @@
+package org.sosly.villageworks.data.zones;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class AABBVillageZone implements IVillageZone {
+
+    private final UUID uuid;
+    private final ZoneType type;
+    private final int id;
+    private String name;
+    private AABB bounds;
+    private List<BlockPos> cachedPOIs;
+    private boolean poiCacheDirty = true;
+
+    public AABBVillageZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
+        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
+        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
+        this.id = id;
+        this.name = name;
+        this.bounds = bounds;
+    }
+
+
+    public AABB getAABB() {
+        return bounds;
+    }
+
+    public void setAABB(AABB bounds) {
+        this.bounds = bounds;
+        this.poiCacheDirty = true;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    @Override
+    public String getName() {
+        if (name != null) {
+            return name;
+        }
+
+        String translationKey = "villageworks.zone." + type.name().toLowerCase();
+        String zoneName = Component.translatable(translationKey).getString();
+        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ZoneShape getShape() {
+        return ZoneShape.AABB;
+    }
+
+    @Override
+    public ZoneType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean containsPosition(BlockPos pos) {
+        if (bounds == null || pos == null) {
+            return false;
+        }
+
+        return pos.getX() >= bounds.minX && pos.getX() <= bounds.maxX &&
+               pos.getY() >= bounds.minY && pos.getY() <= bounds.maxY &&
+               pos.getZ() >= bounds.minZ && pos.getZ() <= bounds.maxZ;
+    }
+
+    @Override
+    public Optional<List<BlockPos>> getPOIs() {
+        if (getType() == ZoneType.NONE) {
+            return Optional.empty();
+        }
+
+        if (poiCacheDirty) {
+            rescanPOIs();
+        }
+
+        return Optional.of(new ArrayList<>(cachedPOIs));
+    }
+
+    private void rescanPOIs() {
+        cachedPOIs = new ArrayList<>();
+
+        if (bounds == null) {
+            poiCacheDirty = false;
+            return;
+        }
+
+        // Need level to scan - will be passed when needed
+        poiCacheDirty = false;
+    }
+
+    public void rescanPOIs(Level level) {
+        if (level == null || getType() == ZoneType.NONE) {
+            cachedPOIs = new ArrayList<>();
+            poiCacheDirty = false;
+            return;
+        }
+
+        cachedPOIs = new ArrayList<>();
+
+        int minX = (int) Math.floor(bounds.minX);
+        int maxX = (int) Math.ceil(bounds.maxX);
+        int minY = (int) Math.floor(bounds.minY);
+        int maxY = (int) Math.ceil(bounds.maxY);
+        int minZ = (int) Math.floor(bounds.minZ);
+        int maxZ = (int) Math.ceil(bounds.maxZ);
+
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    BlockPos pos = new BlockPos(x, y, z);
+                    if (getType().isPOI(pos, level)) {
+                        cachedPOIs.add(pos);
+                    }
+                }
+            }
+        }
+
+        poiCacheDirty = false;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("UUID", uuid.toString());
+        tag.putByte("Type", (byte) type.ordinal());
+        tag.putShort("Id", (short) id);
+        if (name != null) {
+            tag.putString("Name", name);
+        }
+        tag.putByte("Shape", (byte) ZoneShape.AABB.ordinal());
+
+        if (bounds != null) {
+            CompoundTag boundsTag = new CompoundTag();
+            boundsTag.putDouble("MinX", bounds.minX);
+            boundsTag.putDouble("MinY", bounds.minY);
+            boundsTag.putDouble("MinZ", bounds.minZ);
+            boundsTag.putDouble("MaxX", bounds.maxX);
+            boundsTag.putDouble("MaxY", bounds.maxY);
+            boundsTag.putDouble("MaxZ", bounds.maxZ);
+            tag.put("Bounds", boundsTag);
+        }
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        if (tag.contains("Name")) {
+            this.name = tag.getString("Name");
+        }
+
+        if (tag.contains("Bounds")) {
+            CompoundTag boundsTag = tag.getCompound("Bounds");
+            this.bounds = new AABB(
+                boundsTag.getDouble("MinX"),
+                boundsTag.getDouble("MinY"),
+                boundsTag.getDouble("MinZ"),
+                boundsTag.getDouble("MaxX"),
+                boundsTag.getDouble("MaxY"),
+                boundsTag.getDouble("MaxZ")
+            );
+        }
+
+        this.poiCacheDirty = true;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/AbstractVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/AbstractVillageZone.java
@@ -3,6 +3,7 @@ package org.sosly.villageworks.data.zones;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.ZoneShape;
 import org.sosly.villageworks.api.data.ZoneType;
@@ -16,17 +17,23 @@ public abstract class AbstractVillageZone implements IVillageZone {
     private final UUID uuid;
     private final ZoneType type;
     private final int id;
+    private Level level;
     private String name;
+
+    public AbstractVillageZone(UUID uuid, ZoneType type, int id, String name, Level level) {
+        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
+        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
+        this.level = Objects.requireNonNull(level, "Level cannot be null");
+        this.id = id;
+        this.name = name;
+    }
 
     public AbstractVillageZone(UUID uuid, ZoneType type, int id, String name) {
         this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
         this.type = Objects.requireNonNull(type, "Zone type cannot be null");
         this.id = id;
         this.name = name;
-    }
-
-    public AbstractVillageZone(ZoneType type, int id, String name) {
-        this(UUID.randomUUID(), type, id, name);
+        this.level = null;
     }
 
     @Override
@@ -56,6 +63,15 @@ public abstract class AbstractVillageZone implements IVillageZone {
     }
 
     @Override
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.level = Objects.requireNonNull(level, "Level cannot be null");
+    }
+
+    @Override
     public abstract ZoneShape getShape();
 
     @Override
@@ -73,6 +89,7 @@ public abstract class AbstractVillageZone implements IVillageZone {
         if (name != null) {
             tag.putString("Name", name);
         }
+        tag.putString("Level", level.dimension().location().toString());
         return tag;
     }
 

--- a/src/main/java/org/sosly/villageworks/data/zones/AbstractVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/AbstractVillageZone.java
@@ -1,11 +1,15 @@
-package org.sosly.villageworks.data;
+package org.sosly.villageworks.data.zones;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
 import org.sosly.villageworks.api.data.ZoneType;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 public abstract class AbstractVillageZone implements IVillageZone {
@@ -35,7 +39,7 @@ public abstract class AbstractVillageZone implements IVillageZone {
         if (name != null) {
             return name;
         }
-        
+
         String translationKey = "villageworks.zone." + type.name().toLowerCase();
         String zoneName = Component.translatable(translationKey).getString();
         return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
@@ -50,7 +54,16 @@ public abstract class AbstractVillageZone implements IVillageZone {
     public ZoneType getType() {
         return type;
     }
-    
+
+    @Override
+    public abstract ZoneShape getShape();
+
+    @Override
+    public abstract boolean containsPosition(BlockPos pos);
+
+    @Override
+    public abstract Optional<List<BlockPos>> getPOIs();
+
     @Override
     public CompoundTag serializeNBT() {
         CompoundTag tag = new CompoundTag();
@@ -62,7 +75,7 @@ public abstract class AbstractVillageZone implements IVillageZone {
         }
         return tag;
     }
-    
+
     @Override
     public void deserializeNBT(CompoundTag tag) {
         if (tag.contains("Name")) {

--- a/src/main/java/org/sosly/villageworks/data/zones/BlockPosVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/BlockPosVillageZone.java
@@ -2,7 +2,6 @@ package org.sosly.villageworks.data.zones;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.ZoneShape;
@@ -10,25 +9,20 @@ import org.sosly.villageworks.api.data.ZoneType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-public class BlockPosVillageZone implements IVillageZone {
+public class BlockPosVillageZone extends AbstractVillageZone implements IVillageZone {
 
-    private final UUID uuid;
-    private final ZoneType type;
-    private final int id;
-    private String name;
     private BlockPos blockPos;
-    private List<BlockPos> cachedPOIs;
-    private boolean poiCacheDirty = true;
+
+    public BlockPosVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos, Level level) {
+        super(uuid, type, id, name, level);
+        this.blockPos = blockPos;
+    }
 
     public BlockPosVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos) {
-        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
-        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
-        this.id = id;
-        this.name = name;
+        super(uuid, type, id, name);
         this.blockPos = blockPos;
     }
 
@@ -38,28 +32,6 @@ public class BlockPosVillageZone implements IVillageZone {
 
     public void setBlockPos(BlockPos blockPos) {
         this.blockPos = blockPos;
-        this.poiCacheDirty = true;
-    }
-
-    @Override
-    public UUID getUUID() {
-        return uuid;
-    }
-
-    @Override
-    public String getName() {
-        if (name != null) {
-            return name;
-        }
-
-        String translationKey = "villageworks.zone." + type.name().toLowerCase();
-        String zoneName = Component.translatable(translationKey).getString();
-        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
     }
 
     @Override
@@ -67,10 +39,6 @@ public class BlockPosVillageZone implements IVillageZone {
         return ZoneShape.BLOCKPOS;
     }
 
-    @Override
-    public ZoneType getType() {
-        return type;
-    }
 
     @Override
     public boolean containsPosition(BlockPos pos) {
@@ -83,53 +51,22 @@ public class BlockPosVillageZone implements IVillageZone {
 
     @Override
     public Optional<List<BlockPos>> getPOIs() {
-        if (getType() == ZoneType.NONE) {
+        if (getType() == ZoneType.NONE || blockPos == null || getLevel() == null) {
             return Optional.empty();
         }
 
-        if (poiCacheDirty) {
-            rescanPOIs();
+        List<BlockPos> pois = new ArrayList<>();
+        if (getType().isPOI(blockPos, getLevel())) {
+            pois.add(blockPos);
         }
 
-        return Optional.of(new ArrayList<>(cachedPOIs));
+        return Optional.of(pois);
     }
 
-    private void rescanPOIs() {
-        cachedPOIs = new ArrayList<>();
-
-        if (blockPos == null) {
-            poiCacheDirty = false;
-            return;
-        }
-
-        poiCacheDirty = false;
-    }
-
-    public void rescanPOIs(Level level) {
-        if (level == null || getType() == ZoneType.NONE || blockPos == null) {
-            cachedPOIs = new ArrayList<>();
-            poiCacheDirty = false;
-            return;
-        }
-
-        cachedPOIs = new ArrayList<>();
-
-        if (getType().isPOI(blockPos, level)) {
-            cachedPOIs.add(blockPos);
-        }
-
-        poiCacheDirty = false;
-    }
 
     @Override
     public CompoundTag serializeNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString("UUID", uuid.toString());
-        tag.putByte("Type", (byte) type.ordinal());
-        tag.putShort("Id", (short) id);
-        if (name != null) {
-            tag.putString("Name", name);
-        }
+        CompoundTag tag = super.serializeNBT();
         tag.putByte("Shape", (byte) ZoneShape.BLOCKPOS.ordinal());
 
         if (blockPos != null) {
@@ -141,13 +78,10 @@ public class BlockPosVillageZone implements IVillageZone {
 
     @Override
     public void deserializeNBT(CompoundTag tag) {
-        if (tag.contains("Name")) {
-            this.name = tag.getString("Name");
-        }
+        super.deserializeNBT(tag);
 
         if (tag.contains("BlockPos")) {
             this.blockPos = BlockPos.of(tag.getLong("BlockPos"));
         }
-        this.poiCacheDirty = true;
     }
 }

--- a/src/main/java/org/sosly/villageworks/data/zones/BlockPosVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/BlockPosVillageZone.java
@@ -1,0 +1,153 @@
+package org.sosly.villageworks.data.zones;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class BlockPosVillageZone implements IVillageZone {
+
+    private final UUID uuid;
+    private final ZoneType type;
+    private final int id;
+    private String name;
+    private BlockPos blockPos;
+    private List<BlockPos> cachedPOIs;
+    private boolean poiCacheDirty = true;
+
+    public BlockPosVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos) {
+        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
+        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
+        this.id = id;
+        this.name = name;
+        this.blockPos = blockPos;
+    }
+
+    public BlockPos getBlockPos() {
+        return blockPos;
+    }
+
+    public void setBlockPos(BlockPos blockPos) {
+        this.blockPos = blockPos;
+        this.poiCacheDirty = true;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    @Override
+    public String getName() {
+        if (name != null) {
+            return name;
+        }
+
+        String translationKey = "villageworks.zone." + type.name().toLowerCase();
+        String zoneName = Component.translatable(translationKey).getString();
+        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ZoneShape getShape() {
+        return ZoneShape.BLOCKPOS;
+    }
+
+    @Override
+    public ZoneType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean containsPosition(BlockPos pos) {
+        if (blockPos == null || pos == null) {
+            return false;
+        }
+
+        return blockPos.equals(pos);
+    }
+
+    @Override
+    public Optional<List<BlockPos>> getPOIs() {
+        if (getType() == ZoneType.NONE) {
+            return Optional.empty();
+        }
+
+        if (poiCacheDirty) {
+            rescanPOIs();
+        }
+
+        return Optional.of(new ArrayList<>(cachedPOIs));
+    }
+
+    private void rescanPOIs() {
+        cachedPOIs = new ArrayList<>();
+
+        if (blockPos == null) {
+            poiCacheDirty = false;
+            return;
+        }
+
+        poiCacheDirty = false;
+    }
+
+    public void rescanPOIs(Level level) {
+        if (level == null || getType() == ZoneType.NONE || blockPos == null) {
+            cachedPOIs = new ArrayList<>();
+            poiCacheDirty = false;
+            return;
+        }
+
+        cachedPOIs = new ArrayList<>();
+
+        if (getType().isPOI(blockPos, level)) {
+            cachedPOIs.add(blockPos);
+        }
+
+        poiCacheDirty = false;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("UUID", uuid.toString());
+        tag.putByte("Type", (byte) type.ordinal());
+        tag.putShort("Id", (short) id);
+        if (name != null) {
+            tag.putString("Name", name);
+        }
+        tag.putByte("Shape", (byte) ZoneShape.BLOCKPOS.ordinal());
+
+        if (blockPos != null) {
+            tag.putLong("BlockPos", blockPos.asLong());
+        }
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        if (tag.contains("Name")) {
+            this.name = tag.getString("Name");
+        }
+
+        if (tag.contains("BlockPos")) {
+            this.blockPos = BlockPos.of(tag.getLong("BlockPos"));
+        }
+        this.poiCacheDirty = true;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/PathVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/PathVillageZone.java
@@ -17,21 +17,19 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-public class PathVillageZone implements IVillageZone {
+public class PathVillageZone extends AbstractVillageZone implements IVillageZone {
 
-    private final UUID uuid;
-    private final ZoneType type;
-    private final int id;
-    private String name;
     private List<BlockPos> path;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
+    public PathVillageZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path, Level level) {
+        super(uuid, type, id, name, level);
+        this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
+    }
+
     public PathVillageZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
-        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
-        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
-        this.id = id;
-        this.name = name;
+        super(uuid, type, id, name);
         this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
     }
 
@@ -57,34 +55,8 @@ public class PathVillageZone implements IVillageZone {
     }
 
     @Override
-    public UUID getUUID() {
-        return uuid;
-    }
-
-    @Override
-    public String getName() {
-        if (name != null) {
-            return name;
-        }
-
-        String translationKey = "villageworks.zone." + type.name().toLowerCase();
-        String zoneName = Component.translatable(translationKey).getString();
-        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
     public ZoneShape getShape() {
         return ZoneShape.PATH;
-    }
-
-    @Override
-    public ZoneType getType() {
-        return type;
     }
 
     @Override
@@ -98,26 +70,15 @@ public class PathVillageZone implements IVillageZone {
 
     @Override
     public Optional<List<BlockPos>> getPOIs() {
-        if (getType() == ZoneType.NONE) {
+        if (getType() == ZoneType.NONE || getLevel() == null) {
             return Optional.empty();
         }
 
         if (poiCacheDirty) {
-            rescanPOIs();
+            rescanPOIs(getLevel());
         }
 
         return Optional.of(new ArrayList<>(cachedPOIs));
-    }
-
-    private void rescanPOIs() {
-        cachedPOIs = new ArrayList<>();
-
-        if (path.isEmpty()) {
-            poiCacheDirty = false;
-            return;
-        }
-
-        poiCacheDirty = false;
     }
 
     public void rescanPOIs(Level level) {
@@ -140,13 +101,7 @@ public class PathVillageZone implements IVillageZone {
 
     @Override
     public CompoundTag serializeNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString("UUID", uuid.toString());
-        tag.putByte("Type", (byte) type.ordinal());
-        tag.putShort("Id", (short) id);
-        if (name != null) {
-            tag.putString("Name", name);
-        }
+        CompoundTag tag = super.serializeNBT();
         tag.putByte("Shape", (byte) ZoneShape.PATH.ordinal());
 
         ListTag pathList = new ListTag();
@@ -160,9 +115,7 @@ public class PathVillageZone implements IVillageZone {
 
     @Override
     public void deserializeNBT(CompoundTag tag) {
-        if (tag.contains("Name")) {
-            this.name = tag.getString("Name");
-        }
+        super.deserializeNBT(tag);
 
         this.path = new ArrayList<>();
         if (tag.contains("Path", Tag.TAG_LIST)) {

--- a/src/main/java/org/sosly/villageworks/data/zones/PathVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/PathVillageZone.java
@@ -1,0 +1,177 @@
+package org.sosly.villageworks.data.zones;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.LongTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class PathVillageZone implements IVillageZone {
+
+    private final UUID uuid;
+    private final ZoneType type;
+    private final int id;
+    private String name;
+    private List<BlockPos> path;
+    private List<BlockPos> cachedPOIs;
+    private boolean poiCacheDirty = true;
+
+    public PathVillageZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
+        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
+        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
+        this.id = id;
+        this.name = name;
+        this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
+    }
+
+    public List<BlockPos> getPath() {
+        return new ArrayList<>(path);
+    }
+
+    public void setPath(List<BlockPos> path) {
+        this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
+        this.poiCacheDirty = true;
+    }
+
+    public void addPoint(BlockPos point) {
+        if (point != null) {
+            path.add(point);
+            this.poiCacheDirty = true;
+        }
+    }
+
+    public void clearPath() {
+        path.clear();
+        this.poiCacheDirty = true;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    @Override
+    public String getName() {
+        if (name != null) {
+            return name;
+        }
+
+        String translationKey = "villageworks.zone." + type.name().toLowerCase();
+        String zoneName = Component.translatable(translationKey).getString();
+        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ZoneShape getShape() {
+        return ZoneShape.PATH;
+    }
+
+    @Override
+    public ZoneType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean containsPosition(BlockPos pos) {
+        if (pos == null || path.isEmpty()) {
+            return false;
+        }
+
+        return path.contains(pos);
+    }
+
+    @Override
+    public Optional<List<BlockPos>> getPOIs() {
+        if (getType() == ZoneType.NONE) {
+            return Optional.empty();
+        }
+
+        if (poiCacheDirty) {
+            rescanPOIs();
+        }
+
+        return Optional.of(new ArrayList<>(cachedPOIs));
+    }
+
+    private void rescanPOIs() {
+        cachedPOIs = new ArrayList<>();
+
+        if (path.isEmpty()) {
+            poiCacheDirty = false;
+            return;
+        }
+
+        poiCacheDirty = false;
+    }
+
+    public void rescanPOIs(Level level) {
+        if (level == null || getType() == ZoneType.NONE || path.isEmpty()) {
+            cachedPOIs = new ArrayList<>();
+            poiCacheDirty = false;
+            return;
+        }
+
+        cachedPOIs = new ArrayList<>();
+
+        for (BlockPos pos : path) {
+            if (getType().isPOI(pos, level)) {
+                cachedPOIs.add(pos);
+            }
+        }
+
+        poiCacheDirty = false;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("UUID", uuid.toString());
+        tag.putByte("Type", (byte) type.ordinal());
+        tag.putShort("Id", (short) id);
+        if (name != null) {
+            tag.putString("Name", name);
+        }
+        tag.putByte("Shape", (byte) ZoneShape.PATH.ordinal());
+
+        ListTag pathList = new ListTag();
+        for (BlockPos pos : path) {
+            pathList.add(LongTag.valueOf(pos.asLong()));
+        }
+        tag.put("Path", pathList);
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        if (tag.contains("Name")) {
+            this.name = tag.getString("Name");
+        }
+
+        this.path = new ArrayList<>();
+        if (tag.contains("Path", Tag.TAG_LIST)) {
+            ListTag pathList = tag.getList("Path", Tag.TAG_LONG);
+            for (int i = 0; i < pathList.size(); i++) {
+                LongTag longTag = (LongTag) pathList.get(i);
+                this.path.add(BlockPos.of(longTag.getAsLong()));
+            }
+        }
+        this.poiCacheDirty = true;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/RadiusVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/RadiusVillageZone.java
@@ -1,0 +1,181 @@
+package org.sosly.villageworks.data.zones;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class RadiusVillageZone implements IVillageZone {
+
+    private final UUID uuid;
+    private final ZoneType type;
+    private final int id;
+    private String name;
+    private BlockPos center;
+    private int radius;
+    private List<BlockPos> cachedPOIs;
+    private boolean poiCacheDirty = true;
+
+    public RadiusVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
+        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
+        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
+        this.id = id;
+        this.name = name;
+        this.center = center;
+        this.radius = radius;
+    }
+
+    public BlockPos getCenter() {
+        return center;
+    }
+
+    public void setCenter(BlockPos center) {
+        this.center = center;
+        this.poiCacheDirty = true;
+    }
+
+    public int getRadius() {
+        return radius;
+    }
+
+    public void setRadius(int radius) {
+        this.radius = radius;
+        this.poiCacheDirty = true;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    @Override
+    public String getName() {
+        if (name != null) {
+            return name;
+        }
+
+        String translationKey = "villageworks.zone." + type.name().toLowerCase();
+        String zoneName = Component.translatable(translationKey).getString();
+        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ZoneShape getShape() {
+        return ZoneShape.RADIUS;
+    }
+
+    @Override
+    public ZoneType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean containsPosition(BlockPos pos) {
+        if (center == null || pos == null) {
+            return false;
+        }
+
+        double distanceSquared = center.distSqr(pos);
+        return distanceSquared <= radius * radius;
+    }
+
+    @Override
+    public Optional<List<BlockPos>> getPOIs() {
+        if (getType() == ZoneType.NONE) {
+            return Optional.empty();
+        }
+
+        if (poiCacheDirty) {
+            rescanPOIs();
+        }
+
+        return Optional.of(new ArrayList<>(cachedPOIs));
+    }
+
+    private void rescanPOIs() {
+        cachedPOIs = new ArrayList<>();
+
+        if (center == null) {
+            poiCacheDirty = false;
+            return;
+        }
+
+        poiCacheDirty = false;
+    }
+
+    public void rescanPOIs(Level level) {
+        if (level == null || getType() == ZoneType.NONE || center == null) {
+            cachedPOIs = new ArrayList<>();
+            poiCacheDirty = false;
+            return;
+        }
+
+        cachedPOIs = new ArrayList<>();
+
+        int minX = center.getX() - radius;
+        int maxX = center.getX() + radius;
+        int minY = Math.max(level.getMinBuildHeight(), center.getY() - radius);
+        int maxY = Math.min(level.getMaxBuildHeight(), center.getY() + radius);
+        int minZ = center.getZ() - radius;
+        int maxZ = center.getZ() + radius;
+
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    BlockPos pos = new BlockPos(x, y, z);
+                    if (containsPosition(pos) && getType().isPOI(pos, level)) {
+                        cachedPOIs.add(pos);
+                    }
+                }
+            }
+        }
+
+        poiCacheDirty = false;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("UUID", uuid.toString());
+        tag.putByte("Type", (byte) type.ordinal());
+        tag.putShort("Id", (short) id);
+        if (name != null) {
+            tag.putString("Name", name);
+        }
+        tag.putByte("Shape", (byte) ZoneShape.RADIUS.ordinal());
+
+        if (center != null) {
+            tag.putLong("Center", center.asLong());
+        }
+        tag.putInt("Radius", radius);
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        if (tag.contains("Name")) {
+            this.name = tag.getString("Name");
+        }
+
+        if (tag.contains("Center")) {
+            this.center = BlockPos.of(tag.getLong("Center"));
+        }
+        this.radius = tag.getInt("Radius");
+        this.poiCacheDirty = true;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/RadiusVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/RadiusVillageZone.java
@@ -2,7 +2,6 @@ package org.sosly.villageworks.data.zones;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.ZoneShape;
@@ -10,26 +9,24 @@ import org.sosly.villageworks.api.data.ZoneType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-public class RadiusVillageZone implements IVillageZone {
+public class RadiusVillageZone extends AbstractVillageZone implements IVillageZone {
 
-    private final UUID uuid;
-    private final ZoneType type;
-    private final int id;
-    private String name;
     private BlockPos center;
     private int radius;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
+    public RadiusVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
+        super(uuid, type, id, name, level);
+        this.center = center;
+        this.radius = radius;
+    }
+
     public RadiusVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
-        this.uuid = Objects.requireNonNull(uuid, "UUID cannot be null");
-        this.type = Objects.requireNonNull(type, "Zone type cannot be null");
-        this.id = id;
-        this.name = name;
+        super(uuid, type, id, name);
         this.center = center;
         this.radius = radius;
     }
@@ -53,34 +50,8 @@ public class RadiusVillageZone implements IVillageZone {
     }
 
     @Override
-    public UUID getUUID() {
-        return uuid;
-    }
-
-    @Override
-    public String getName() {
-        if (name != null) {
-            return name;
-        }
-
-        String translationKey = "villageworks.zone." + type.name().toLowerCase();
-        String zoneName = Component.translatable(translationKey).getString();
-        return Component.translatable("villageworks.zone.numbered", zoneName, id).getString();
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
     public ZoneShape getShape() {
         return ZoneShape.RADIUS;
-    }
-
-    @Override
-    public ZoneType getType() {
-        return type;
     }
 
     @Override
@@ -95,26 +66,15 @@ public class RadiusVillageZone implements IVillageZone {
 
     @Override
     public Optional<List<BlockPos>> getPOIs() {
-        if (getType() == ZoneType.NONE) {
+        if (getType() == ZoneType.NONE || getLevel() == null) {
             return Optional.empty();
         }
 
         if (poiCacheDirty) {
-            rescanPOIs();
+            rescanPOIs(getLevel());
         }
 
         return Optional.of(new ArrayList<>(cachedPOIs));
-    }
-
-    private void rescanPOIs() {
-        cachedPOIs = new ArrayList<>();
-
-        if (center == null) {
-            poiCacheDirty = false;
-            return;
-        }
-
-        poiCacheDirty = false;
     }
 
     public void rescanPOIs(Level level) {
@@ -149,13 +109,7 @@ public class RadiusVillageZone implements IVillageZone {
 
     @Override
     public CompoundTag serializeNBT() {
-        CompoundTag tag = new CompoundTag();
-        tag.putString("UUID", uuid.toString());
-        tag.putByte("Type", (byte) type.ordinal());
-        tag.putShort("Id", (short) id);
-        if (name != null) {
-            tag.putString("Name", name);
-        }
+        CompoundTag tag = super.serializeNBT();
         tag.putByte("Shape", (byte) ZoneShape.RADIUS.ordinal());
 
         if (center != null) {
@@ -168,9 +122,7 @@ public class RadiusVillageZone implements IVillageZone {
 
     @Override
     public void deserializeNBT(CompoundTag tag) {
-        if (tag.contains("Name")) {
-            this.name = tag.getString("Name");
-        }
+        super.deserializeNBT(tag);
 
         if (tag.contains("Center")) {
             this.center = BlockPos.of(tag.getLong("Center"));

--- a/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
@@ -1,0 +1,86 @@
+package org.sosly.villageworks.data.zones;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.phys.AABB;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneShape;
+import org.sosly.villageworks.api.data.ZoneType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ZoneFactory {
+
+    public static IVillageZone createZone(ZoneShape shape, ZoneType type, int id, String name) {
+        UUID uuid = UUID.randomUUID();
+        return createZone(shape, uuid, type, id, name);
+    }
+
+    public static IVillageZone createZone(ZoneShape shape, UUID uuid, ZoneType type, int id, String name) {
+        return switch (shape) {
+            case AABB -> new AABBVillageZone(uuid, type, id, name, new AABB(0, 0, 0, 1, 1, 1));
+            case RADIUS -> new RadiusVillageZone(uuid, type, id, name, BlockPos.ZERO, 1);
+            case BLOCKPOS -> new BlockPosVillageZone(uuid, type, id, name, BlockPos.ZERO);
+            case PATH -> new PathVillageZone(uuid, type, id, name, new ArrayList<>());
+        };
+    }
+
+    public static IVillageZone createAABBZone(ZoneType type, int id, String name, AABB bounds) {
+        UUID uuid = UUID.randomUUID();
+        return createAABBZone(uuid, type, id, name, bounds);
+    }
+
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
+        return new AABBVillageZone(uuid, type, id, name, bounds);
+    }
+
+    public static IVillageZone createRadiusZone(ZoneType type, int id, String name, BlockPos center, int radius) {
+        UUID uuid = UUID.randomUUID();
+        return createRadiusZone(uuid, type, id, name, center, radius);
+    }
+
+    public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
+        return new RadiusVillageZone(uuid, type, id, name, center, radius);
+    }
+
+    public static IVillageZone createBlockPosZone(ZoneType type, int id, String name, BlockPos pos) {
+        UUID uuid = UUID.randomUUID();
+        return createBlockPosZone(uuid, type, id, name, pos);
+    }
+
+    public static IVillageZone createBlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos pos) {
+        return new BlockPosVillageZone(uuid, type, id, name, pos);
+    }
+
+    public static IVillageZone createPathZone(ZoneType type, int id, String name, List<BlockPos> path) {
+        UUID uuid = UUID.randomUUID();
+        return createPathZone(uuid, type, id, name, path);
+    }
+
+    public static IVillageZone createPathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
+        return new PathVillageZone(uuid, type, id, name, path != null ? path : new ArrayList<>());
+    }
+
+    public static IVillageZone deserializeFromNBT(CompoundTag tag) {
+        if (!tag.contains("UUID") || !tag.contains("Type") || !tag.contains("Shape")) {
+            return null;
+        }
+
+        try {
+            UUID uuid = UUID.fromString(tag.getString("UUID"));
+            ZoneType type = ZoneType.values()[tag.getByte("Type")];
+            ZoneShape shape = ZoneShape.values()[tag.getByte("Shape")];
+            int id = tag.getShort("Id");
+            String name = tag.contains("Name") ? tag.getString("Name") : null;
+
+            IVillageZone zone = createZone(shape, uuid, type, id, name);
+            zone.deserializeNBT(tag);
+            return zone;
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
@@ -1,7 +1,12 @@
 package org.sosly.villageworks.data.zones;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.ZoneShape;
@@ -27,36 +32,48 @@ public class ZoneFactory {
         };
     }
 
-    public static IVillageZone createAABBZone(ZoneType type, int id, String name, AABB bounds) {
+    public static IVillageZone createAABBZone(ZoneType type, int id, String name, AABB bounds, Level level) {
         UUID uuid = UUID.randomUUID();
-        return createAABBZone(uuid, type, id, name, bounds);
+        return createAABBZone(uuid, type, id, name, bounds, level);
+    }
+
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, AABB bounds, Level level) {
+        return new AABBVillageZone(uuid, type, id, name, bounds, level);
     }
 
     public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
         return new AABBVillageZone(uuid, type, id, name, bounds);
     }
 
-    public static IVillageZone createRadiusZone(ZoneType type, int id, String name, BlockPos center, int radius) {
+    public static IVillageZone createRadiusZone(ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
         UUID uuid = UUID.randomUUID();
-        return createRadiusZone(uuid, type, id, name, center, radius);
+        return createRadiusZone(uuid, type, id, name, center, radius, level);
+    }
+
+    public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
+        return new RadiusVillageZone(uuid, type, id, name, center, radius, level);
     }
 
     public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
         return new RadiusVillageZone(uuid, type, id, name, center, radius);
     }
 
-    public static IVillageZone createBlockPosZone(ZoneType type, int id, String name, BlockPos pos) {
+    public static IVillageZone createBlockPosZone(ZoneType type, int id, String name, BlockPos pos, Level level) {
         UUID uuid = UUID.randomUUID();
-        return createBlockPosZone(uuid, type, id, name, pos);
+        return createBlockPosZone(uuid, type, id, name, pos, level);
     }
 
-    public static IVillageZone createBlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos pos) {
-        return new BlockPosVillageZone(uuid, type, id, name, pos);
+    public static IVillageZone createBlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos pos, Level level) {
+        return new BlockPosVillageZone(uuid, type, id, name, pos, level);
     }
 
-    public static IVillageZone createPathZone(ZoneType type, int id, String name, List<BlockPos> path) {
+    public static IVillageZone createPathZone(ZoneType type, int id, String name, List<BlockPos> path, Level level) {
         UUID uuid = UUID.randomUUID();
-        return createPathZone(uuid, type, id, name, path);
+        return createPathZone(uuid, type, id, name, path, level);
+    }
+
+    public static IVillageZone createPathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path, Level level) {
+        return new PathVillageZone(uuid, type, id, name, path != null ? path : new ArrayList<>(), level);
     }
 
     public static IVillageZone createPathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
@@ -77,6 +94,24 @@ public class ZoneFactory {
 
             IVillageZone zone = createZone(shape, uuid, type, id, name);
             zone.deserializeNBT(tag);
+
+            if (!(zone instanceof AbstractVillageZone abstractZone)) {
+                return zone;
+            }
+            if (!tag.contains("Level")) {
+                return zone;
+            }
+
+            String levelKey = tag.getString("Level");
+            ResourceLocation dimensionId = new ResourceLocation(levelKey);
+            ResourceKey<Level> levelResourceKey = ResourceKey.create(Registries.DIMENSION, dimensionId);
+
+            Level level = Minecraft.getInstance().level.getServer().getLevel(levelResourceKey);
+            if (level == null) {
+                return zone;
+            }
+
+            abstractZone.setLevel(level);
             return zone;
 
         } catch (Exception e) {


### PR DESCRIPTION
# Implement zone shapes and commands
Adds concrete zone shape implementations and comprehensive zone management commands with tab completion and persistence.

## Changes
- Add four concrete zone shape classes: AABBVillageZone, RadiusVillageZone, BlockPosVillageZone, PathVillageZone
- Create comprehensive `/vw zone` command system with all subcommands
- Implement smart tab completion for village UUIDs and zone UUIDs
- Add support for relative coordinates (`~ ~ ~`) in zone creation commands
- Create zone info command showing bounds, type, and discovered POIs with block names
- Add zone factory for proper creation and NBT deserialization
- Fix zone persistence with proper serialization/deserialization
- Implement custom argument types for zone types with validation
- Add automatic POI detection and caching within zones
- Create ModifiableZoneList to automatically mark chunks dirty on zone modifications

## Related Issues
Resolves #22

## Implementation Notes
- Zones use a factory pattern for creation and deserialization to ensure proper UUID management
- POI scanning is cached and only rescanned when zone boundaries change or explicitly requested
- Zone commands use context-aware tab completion (zone UUIDs filtered by selected village)
- ModifiableZoneList wrapper automatically handles persistence without requiring manual markDirty calls
- Zone info displays are truncated to prevent chat spam (max 5 path points, 10 POIs shown)

## Breaking Changes
None