### PR TITLE
feat: implement village memory module and villager assignment

### DIFF
--- a/src/main/java/org/sosly/villageworks/command/VillageCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageCommand.java
@@ -11,6 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.data.VillageData;
 
@@ -189,6 +190,14 @@ public class VillageCommand {
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
+                    
+                    LevelChunk chunk = level.getChunk(townHall.x, townHall.z);
+                    var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+                    if (villageCapability != null) {
+                        int villagerCount = villageCapability.getVillagerIds().size();
+                        source.sendSuccess(() ->
+                            Component.literal("Villagers: " + villagerCount), false);
+                    }
 
                     return 1;
                 })
@@ -242,6 +251,14 @@ public class VillageCommand {
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
+                    
+                    LevelChunk chunk = level.getChunk(townHall.x, townHall.z);
+                    var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+                    if (villageCapability != null) {
+                        int villagerCount = villageCapability.getVillagerIds().size();
+                        source.sendSuccess(() ->
+                            Component.literal("Villagers: " + villagerCount), false);
+                    }
                     
                     return 1;
                 })

--- a/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageWorksCommand.java
@@ -14,6 +14,7 @@ public class VillageWorksCommand {
         ExhaustCommand.register(vwCommand);
         HungerCommand.register(vwCommand);
         VillageCommand.register(vwCommand);
+        VillagerCommand.register(vwCommand);
         ZoneCommand.register(vwCommand);
 
         dispatcher.register(vwCommand);

--- a/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
@@ -1,0 +1,116 @@
+package org.sosly.villageworks.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.capability.village.VillageCapability;
+import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
+import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.entity.Villager;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+public class VillagerCommand {
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
+        parentCommand.then(Commands.literal("villager")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .then(Commands.literal("village")
+                    .executes(VillagerCommand::queryVillageAssignment)
+                    .then(Commands.argument("villageUUID", VillageUUIDArgument.villageUUID())
+                        .suggests((context, builder) -> VillageUUIDArgument.suggest(context, builder))
+                        .executes(VillagerCommand::assignVillage)))));
+    }
+
+    private static int queryVillageAssignment(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            int checkedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    Optional<UUID> villageId = villager.getVillage();
+                    
+                    if (villageId.isPresent()) {
+                        context.getSource().sendSuccess(() ->
+                            Component.literal(String.format("Villager %s is assigned to village %s",
+                                villager.getDisplayName().getString(),
+                                villageId.get())), false);
+                    } else {
+                        context.getSource().sendSuccess(() ->
+                            Component.literal(String.format("Villager %s is not assigned to any village",
+                                villager.getDisplayName().getString())), false);
+                    }
+                    
+                    checkedCount++;
+                }
+            }
+
+            if (checkedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            return checkedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to query village assignment: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int assignVillage(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
+            ServerLevel level = context.getSource().getLevel();
+            
+            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
+                .map(manager -> {
+                    VillageData village = manager.getVillageById(villageId);
+                    if (village == null) {
+                        context.getSource().sendFailure(Component.literal("Village " + villageId + " not found"));
+                        return 0;
+                    }
+
+                    int assignedCount = 0;
+                    for (Entity entity : entities) {
+                        if (entity instanceof Villager villager) {
+                            villager.setVillage(villageId);
+                            assignedCount++;
+                        }
+                    }
+
+                    if (assignedCount == 0) {
+                        context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                        return 0;
+                    }
+
+                    final int finalAssignedCount = assignedCount;
+                    final UUID finalVillageId = villageId;
+                    context.getSource().sendSuccess(() ->
+                        Component.literal(String.format("Assigned %d villager(s) to village %s",
+                            finalAssignedCount, finalVillageId)), true);
+
+                    return assignedCount;
+                })
+                .orElseGet(() -> {
+                    context.getSource().sendFailure(Component.literal("Villages capability not available"));
+                    return 0;
+                });
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to assign village: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
@@ -1,7 +1,6 @@
 package org.sosly.villageworks.entity;
 
 import com.mojang.serialization.Codec;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -9,9 +8,9 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villageworks.VillageWorks;
 
+import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.UUID;
-import java.nio.ByteBuffer;
 
 public class MemoryModuleTypes {
     public static final DeferredRegister<MemoryModuleType<?>> MEMORY_MODULE_TYPES =

--- a/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
@@ -1,6 +1,7 @@
 package org.sosly.villageworks.entity;
 
 import com.mojang.serialization.Codec;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -9,6 +10,8 @@ import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villageworks.VillageWorks;
 
 import java.util.Optional;
+import java.util.UUID;
+import java.nio.ByteBuffer;
 
 public class MemoryModuleTypes {
     public static final DeferredRegister<MemoryModuleType<?>> MEMORY_MODULE_TYPES =
@@ -22,6 +25,25 @@ public class MemoryModuleTypes {
 
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_STARVING =
         MEMORY_MODULE_TYPES.register("is_starving", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+
+    public static final RegistryObject<MemoryModuleType<UUID>> VILLAGE =
+        MEMORY_MODULE_TYPES.register("village", () -> new MemoryModuleType<>(Optional.of(
+            Codec.BYTE_BUFFER.xmap(
+                buffer -> {
+                    byte[] bytes = new byte[buffer.remaining()];
+                    buffer.get(bytes);
+                    ByteBuffer bb = ByteBuffer.wrap(bytes);
+                    return new UUID(bb.getLong(), bb.getLong());
+                },
+                uuid -> {
+                    ByteBuffer buffer = ByteBuffer.allocate(16);
+                    buffer.putLong(uuid.getMostSignificantBits());
+                    buffer.putLong(uuid.getLeastSignificantBits());
+                    buffer.flip();
+                    return buffer;
+                }
+            )
+        )));
 
     public static void register(IEventBus eventBus) {
         MEMORY_MODULE_TYPES.register(eventBus);

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -19,6 +19,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.Entity.RemovalReason;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -29,6 +30,8 @@ import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.schedule.Schedule;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -38,8 +41,13 @@ import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.data.LivingEntityFoodData;
 import org.sosly.villageworks.entity.ai.behavior.VillagerGoalPackages;
 import org.sosly.villageworks.entity.ai.SensorTypes;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.capability.village.VillageCapability;
+import org.sosly.villageworks.data.VillageData;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.UUID;
 
 public class Villager extends PathfinderMob {
     private final LivingEntityFoodData foodData;
@@ -62,7 +70,8 @@ public class Villager extends PathfinderMob {
         MemoryModuleType.LAST_WOKEN,
         MemoryModuleTypes.CAN_EAT.get(),
         MemoryModuleTypes.IS_HUNGRY.get(),
-        MemoryModuleTypes.IS_STARVING.get()
+        MemoryModuleTypes.IS_STARVING.get(),
+        MemoryModuleTypes.VILLAGE.get()
     );
 
     private static final ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = ImmutableList.of(
@@ -146,6 +155,11 @@ public class Villager extends PathfinderMob {
             inventoryItem.save(itemTag);
             tag.put("InventoryItem", itemTag);
         }
+
+        Optional<UUID> villageId = this.brain.getMemory(MemoryModuleTypes.VILLAGE.get());
+        if (villageId.isPresent()) {
+            tag.putString("VillageId", villageId.get().toString());
+        }
     }
 
     @Override
@@ -157,6 +171,12 @@ public class Villager extends PathfinderMob {
             ItemStack inventoryItem = ItemStack.of(itemTag);
             this.inventory.setItem(0, inventoryItem);
         }
+
+        if (tag.contains("VillageId")) {
+            UUID villageId = UUID.fromString(tag.getString("VillageId"));
+            this.brain.setMemory(MemoryModuleTypes.VILLAGE.get(), villageId);
+        }
+
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());
         }
@@ -173,6 +193,12 @@ public class Villager extends PathfinderMob {
     @Override
     public boolean removeWhenFarAway(double distance) {
         return false;
+    }
+
+    @Override
+    public void remove(@NotNull RemovalReason reason) {
+        clearVillage();
+        super.remove(reason);
     }
 
     @Override
@@ -214,6 +240,97 @@ public class Villager extends PathfinderMob {
         return this.brain.getMemory(MemoryModuleType.HOME)
             .map(GlobalPos::pos)
             .orElse(null);
+    }
+
+    public Optional<UUID> getVillage() {
+        return this.brain.getMemory(MemoryModuleTypes.VILLAGE.get());
+    }
+
+    public void setVillage(UUID villageId) {
+        if (villageId == null) {
+            clearVillage();
+            return;
+        }
+
+        Optional<UUID> currentVillageId = getVillage();
+        if (currentVillageId.isPresent() && currentVillageId.get().equals(villageId)) {
+            return;
+        }
+
+        if (!(this.level() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        var villages = serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villages == null) {
+            return;
+        }
+
+        if (currentVillageId.isPresent()) {
+            VillageData oldVillage = villages.getVillageById(currentVillageId.get());
+            if (oldVillage == null) {
+                return;
+            }
+
+            ChunkPos oldTownHallPos = oldVillage.getTownHallPos();
+            LevelChunk oldChunk = serverLevel.getChunk(oldTownHallPos.x, oldTownHallPos.z);
+            var oldVillageCapability = oldChunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+            if (oldVillageCapability == null) {
+                return;
+            }
+
+            oldVillageCapability.removeVillager(this.getUUID());
+        }
+
+        VillageData newVillage = villages.getVillageById(villageId);
+        if (newVillage == null) {
+            return;
+        }
+
+        ChunkPos newTownHallPos = newVillage.getTownHallPos();
+        LevelChunk newChunk = serverLevel.getChunk(newTownHallPos.x, newTownHallPos.z);
+        var newVillageCapability = newChunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (newVillageCapability == null) {
+            return;
+        }
+
+        newVillageCapability.assignVillager(this.getUUID());
+        this.brain.setMemory(MemoryModuleTypes.VILLAGE.get(), villageId);
+        VillageWorks.LOGGER.info("Villager {} assigned to village {}", this.getUUID(), villageId);
+    }
+
+    public void clearVillage() {
+        Optional<UUID> currentVillageId = getVillage();
+        if (currentVillageId.isEmpty()) {
+            return;
+        }
+
+        if (!(this.level() instanceof ServerLevel serverLevel)) {
+            this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
+            return;
+        }
+
+        var manager = serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (manager == null) {
+            this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
+            return;
+        }
+
+        VillageData village = manager.getVillageById(currentVillageId.get());
+        if (village == null) {
+            this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
+            return;
+        }
+
+        ChunkPos townHallPos = village.getTownHallPos();
+        LevelChunk chunk = serverLevel.getChunk(townHallPos.x, townHallPos.z);
+        var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability != null) {
+            villageCapability.removeVillager(this.getUUID());
+        }
+
+        this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
+        VillageWorks.LOGGER.info("Villager {} village assignment cleared", this.getUUID());
     }
 
     public LivingEntityFoodData getFoodData() {


### PR DESCRIPTION
# Implement village memory module and villager assignment

Establishes bidirectional relationship between villagers and villages with proper memory management and command interface.

## Changes
- Added VILLAGE MemoryModuleType with efficient ByteBuffer codec for UUID serialization
- Implemented helper methods on Villager entity (getVillage, setVillage, clearVillage)
- Created VillagerCommand with assignment and query operations
- Added NBT persistence for village assignments across world saves
- Implemented automatic cleanup when villagers are removed or reassigned
- Updated /vw village info command to display villager count

## Commands Added
- `/vw villager <selector> village` - Query current village assignment
- `/vw villager <selector> village <villageUUID>` - Assign villagers to village

## Technical Details
- Used ByteBuffer codec for more efficient UUID storage in memory modules
- Proper capability resolution with early returns instead of nested callbacks
- Bidirectional relationship management (villager tracks village, village tracks villagers)
- Clean separation of concerns between memory management and capability updates

## Related Issues
Resolves #20

## Testing
- Spawned villagers and verified assignment commands work
- Tested persistence across world saves
- Verified cleanup on villager death/removal
- Confirmed reassignment properly removes from previous village
- Validated /vw village info shows correct villager count

## Breaking Changes
None

## Notes
This implementation uses the current village capability chunk assumption. Issue #30 tracks the architectural fix needed to properly separate town hall position from capability storage location.