### PR TITLE
Fix village capability chunk assumption

### DIFF
--- a/src/main/java/org/sosly/villageworks/api/capability/IVillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillageCapability.java
@@ -26,9 +26,14 @@ public interface IVillageCapability {
     UUID getVillageId();
     
     /**
-     * @return Position of the chunk containing the Town Hall
+     * @return Position of the Town Hall block
      */
-    ChunkPos getTownHallPos();
+    BlockPos getTownHallPos();
+    
+    /**
+     * @return Position of the chunk where this village capability is stored
+     */
+    ChunkPos getVillageStartingChunk();
     
     /**
      * @return All zones within this village

--- a/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
@@ -1,5 +1,6 @@
 package org.sosly.villageworks.api.capability;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import org.sosly.villageworks.data.VillageData;
 
@@ -21,12 +22,12 @@ public interface IVillagesCapability {
 
     /**
      * Creates a new village with the specified parameters.
-     * @param townHallPos Chunk position for the village center
+     * @param townHallPos Block position for the town hall
      * @param villageName Unique name for the village
      * @param squadius Square radius in chunks (1-16)
      * @return UUID of created village, or null if creation failed
      */
-    UUID createVillage(ChunkPos townHallPos, String villageName, int squadius);
+    UUID createVillage(BlockPos townHallPos, String villageName, int squadius);
 
     /**
      * Removes a village by its unique identifier.

--- a/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
@@ -101,9 +101,10 @@ public class TownHallBlock extends BaseEntityBlock {
         }
         
         VillageData village = villagesCapability.getVillageById(townHall.getVillageId());
-        if (village != null && pos.equals(village.getTownHallBlockPos())) {
-            village.setTownHallBlockPos(null);
-            VillageWorks.LOGGER.info("Cleared town hall position for village {} at {}", 
+        if (village != null && pos.equals(village.getTownHallPos())) {
+            // Remove the entire village when its town hall is destroyed
+            villagesCapability.removeVillage(townHall.getVillageId());
+            VillageWorks.LOGGER.info("Removed village {} after town hall destruction at {}", 
                 village.getVillageName(), pos);
         }
     }

--- a/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
+++ b/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
@@ -58,19 +58,13 @@ public class TownHallBlockEntity extends BlockEntity {
     }
 
     private void handleExistingVillage(ServerLevel level, VillageData village, Player player) {
-        if (village.getTownHallBlockPos() == null) {
-            VillageWorks.LOGGER.info("Town Hall placed at {} for existing village {}",
-                worldPosition, village.getVillageName());
-            village.setTownHallBlockPos(worldPosition);
-            setVillageId(village.getVillageId());
-            return;
-        }
-
+        BlockPos existingTownHall = village.getTownHallPos();
+        
         VillageWorks.LOGGER.error("Cannot place Town Hall at {} - village {} already has one at {}",
-            worldPosition, village.getVillageName(), village.getTownHallBlockPos());
+            worldPosition, village.getVillageName(), existingTownHall);
         if (player != null) {
             player.sendSystemMessage(Component.translatable("villageworks.townhall.already_exists",
-                village.getVillageName(), village.getTownHallBlockPos().toShortString()));
+                village.getVillageName(), existingTownHall.toShortString()));
         }
         level.destroyBlock(worldPosition, true);
     }
@@ -81,7 +75,7 @@ public class TownHallBlockEntity extends BlockEntity {
             ? Component.translatable("villageworks.village.default_name", player.getName().getString()).getString()
             : "Village_" + System.currentTimeMillis();
 
-        UUID newVillageId = villagesCapability.createVillage(chunkPos, villageName, 3);
+        UUID newVillageId = villagesCapability.createVillage(worldPosition, villageName, 3);
 
         if (newVillageId == null) {
             VillageWorks.LOGGER.error("Failed to create village at {} - likely too close to another village", worldPosition);
@@ -93,10 +87,6 @@ public class TownHallBlockEntity extends BlockEntity {
         }
 
         setVillageId(newVillageId);
-        VillageData newVillage = villagesCapability.getVillageById(newVillageId);
-        if (newVillage != null) {
-            newVillage.setTownHallBlockPos(worldPosition);
-        }
         VillageWorks.LOGGER.info("Created village {} at {} with ID {} and town hall at {}",
             villageName, chunkPos, newVillageId, worldPosition);
     }

--- a/src/main/java/org/sosly/villageworks/capability/Capabilities.java
+++ b/src/main/java/org/sosly/villageworks/capability/Capabilities.java
@@ -40,12 +40,19 @@ public class Capabilities {
     public static void onAttachCapabilities(AttachCapabilitiesEvent<LevelChunk> event) {
         LevelChunk chunk = event.getObject();
 
-        if (!isVillageCenter(chunk)) {
+        var villagesCapability = chunk.getLevel().getCapability(VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return;
+        }
+        
+        var villageData = villagesCapability.getVillageAt(chunk.getPos());
+        if (villageData == null || !chunk.getPos().equals(villageData.getVillageStartingChunk())) {
             return;
         }
 
-        UUID villageId = UUID.randomUUID();
-        VillageProvider provider = new VillageProvider(villageId, chunk.getPos());
+        UUID villageId = villageData.getVillageId();
+        BlockPos townHallPos = villageData.getTownHallPos();
+        VillageProvider provider = new VillageProvider(villageId, townHallPos, chunk.getPos());
 
         provider.getCapability(VILLAGE_CAPABILITY, null)
             .ifPresent(cap -> {
@@ -71,11 +78,5 @@ public class Capabilities {
             });
 
         event.addCapability(VILLAGES_CAPABILITY_KEY, provider);
-    }
-
-    private static boolean isVillageCenter(LevelChunk chunk) {
-        return chunk.getLevel().getCapability(VILLAGES_CAPABILITY)
-            .map(villagesCapability -> villagesCapability.getVillageAt(chunk.getPos()) != null)
-            .orElse(false);
     }
 }

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
@@ -12,15 +12,17 @@ import java.util.*;
 public class VillageCapability implements IVillageCapability {
     
     private final UUID villageId;
-    private final ChunkPos townHallPos;
+    private final BlockPos townHallPos;
+    private final ChunkPos villageStartingChunk;
     private final List<IVillageZone> zones;
     private final Set<UUID> villagerIds;
     private final Map<UUID, Permission> playerPermissions;
     private WeakReference<LevelChunk> ownerChunk;
     
-    public VillageCapability(UUID villageId, ChunkPos townHallPos) {
+    public VillageCapability(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk) {
         this.villageId = villageId;
         this.townHallPos = townHallPos;
+        this.villageStartingChunk = villageStartingChunk;
         this.zones = new ArrayList<>();
         this.villagerIds = new HashSet<>();
         this.playerPermissions = new HashMap<>();
@@ -33,8 +35,13 @@ public class VillageCapability implements IVillageCapability {
     }
     
     @Override
-    public ChunkPos getTownHallPos() {
+    public BlockPos getTownHallPos() {
         return townHallPos;
+    }
+    
+    @Override
+    public ChunkPos getVillageStartingChunk() {
+        return villageStartingChunk;
     }
     
     @Override

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
@@ -1,5 +1,6 @@
 package org.sosly.villageworks.capability.village;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -22,8 +23,8 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
     private final VillageCapability capability;
     private final LazyOptional<IVillageCapability> lazyOptional;
 
-    public VillageProvider(UUID villageId, ChunkPos townHallPos) {
-        this.capability = new VillageCapability(villageId, townHallPos);
+    public VillageProvider(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk) {
+        this.capability = new VillageCapability(villageId, townHallPos, villageStartingChunk);
         this.lazyOptional = LazyOptional.of(() -> capability);
     }
 
@@ -41,7 +42,8 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
         CompoundTag tag = new CompoundTag();
 
         tag.putString("VillageId", capability.getVillageId().toString());
-        tag.putLong("TownHallPos", capability.getTownHallPos().toLong());
+        tag.putLong("TownHallPos", capability.getTownHallPos().asLong());
+        tag.putLong("VillageStartingChunk", capability.getVillageStartingChunk().toLong());
 
         ListTag villagerList = new ListTag();
         for (UUID villagerId : capability.getVillagerIds()) {

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
@@ -1,5 +1,6 @@
 package org.sosly.villageworks.capability.villages;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
@@ -35,7 +36,7 @@ public class VillagesCapability implements IVillagesCapability {
     }
 
     @Override
-    public UUID createVillage(ChunkPos townHallPos, String villageName, int squadius) {
+    public UUID createVillage(BlockPos townHallPos, String villageName, int squadius) {
         if (townHallPos == null || villageName == null || villageName.trim().isEmpty()) {
             return null;
         }
@@ -49,7 +50,8 @@ public class VillagesCapability implements IVillagesCapability {
         }
 
         UUID villageId = UUID.randomUUID();
-        VillageData newVillage = new VillageData(villageId, townHallPos, villageName, squadius);
+        ChunkPos villageStartingChunk = new ChunkPos(townHallPos);
+        VillageData newVillage = new VillageData(villageId, townHallPos, villageStartingChunk, villageName, squadius);
 
         int minDistance = 30;
         for (VillageData existingVillage : villages.values()) {

--- a/src/main/java/org/sosly/villageworks/command/VillageCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageCommand.java
@@ -59,11 +59,10 @@ public class VillageCommand {
 
             ServerLevel level = source.getLevel();
             BlockPos pos = entity.blockPosition();
-            ChunkPos chunkPos = new ChunkPos(pos);
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    UUID villageId = manager.createVillage(chunkPos, villageName, squadius);
+                    UUID villageId = manager.createVillage(pos, villageName, squadius);
                     if (villageId == null) {
                         source.sendFailure(Component.literal("Failed to create village"));
                         return 0;
@@ -132,10 +131,12 @@ public class VillageCommand {
                         Component.literal("Villages in " + level.dimension().location() + ":"), false);
 
                     for (VillageData village : villages) {
-                        ChunkPos pos = village.getTownHallPos();
+                        BlockPos townHall = village.getTownHallPos();
+                        ChunkPos chunkPos = new ChunkPos(townHall);
                         source.sendSuccess(() ->
                             Component.literal("- " + village.getVillageName() +
-                                            " at chunk (" + pos.x + ", " + pos.z + ") " +
+                                            " at block (" + townHall.getX() + ", " + townHall.getY() + ", " + townHall.getZ() + ") " +
+                                            "chunk (" + chunkPos.x + ", " + chunkPos.z + ") " +
                                             "squadius " + village.getSquadius()), false);
                     }
 
@@ -172,26 +173,29 @@ public class VillageCommand {
                         return 1;
                     }
 
-                    ChunkPos townHall = village.getTownHallPos();
+                    BlockPos townHall = village.getTownHallPos();
+                    ChunkPos townHallChunk = new ChunkPos(townHall);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
                     int squadius = village.getSquadius();
-                    int minX = townHall.x - squadius;
-                    int maxX = townHall.x + squadius;
-                    int minZ = townHall.z - squadius;
-                    int maxZ = townHall.z + squadius;
+                    int minX = townHallChunk.x - squadius;
+                    int maxX = townHallChunk.x + squadius;
+                    int minZ = townHallChunk.z - squadius;
+                    int maxZ = townHallChunk.z + squadius;
 
                     source.sendSuccess(() ->
                         Component.literal("Village: " + village.getVillageName()), false);
                     source.sendSuccess(() ->
                         Component.literal("UUID: " + village.getVillageId().toString()), false);
                     source.sendSuccess(() ->
-                        Component.literal("Town Hall: chunk (" + townHall.x + ", " + townHall.z + ")"), false);
+                        Component.literal("Town Hall: block (" + townHall.getX() + ", " + townHall.getY() + ", " + townHall.getZ() + ") " +
+                                        "chunk (" + townHallChunk.x + ", " + townHallChunk.z + ")"), false);
                     source.sendSuccess(() ->
                         Component.literal("Squadius: " + squadius + " (covers " +
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
                     
-                    LevelChunk chunk = level.getChunk(townHall.x, townHall.z);
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
                     var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
                     if (villageCapability != null) {
                         int villagerCount = villageCapability.getVillagerIds().size();
@@ -233,26 +237,29 @@ public class VillageCommand {
                     
                     final VillageData villageData = village;
                     
-                    ChunkPos townHall = villageData.getTownHallPos();
+                    BlockPos townHall = villageData.getTownHallPos();
+                    ChunkPos townHallChunk = new ChunkPos(townHall);
+                    ChunkPos villageChunk = villageData.getVillageStartingChunk();
                     int squadius = villageData.getSquadius();
-                    int minX = townHall.x - squadius;
-                    int maxX = townHall.x + squadius;
-                    int minZ = townHall.z - squadius;
-                    int maxZ = townHall.z + squadius;
+                    int minX = townHallChunk.x - squadius;
+                    int maxX = townHallChunk.x + squadius;
+                    int minZ = townHallChunk.z - squadius;
+                    int maxZ = townHallChunk.z + squadius;
                     
                     source.sendSuccess(() ->
                         Component.literal("Village: " + villageData.getVillageName()), false);
                     source.sendSuccess(() ->
                         Component.literal("UUID: " + villageData.getVillageId().toString()), false);
                     source.sendSuccess(() ->
-                        Component.literal("Town Hall: chunk (" + townHall.x + ", " + townHall.z + ")"), false);
+                        Component.literal("Town Hall: block (" + townHall.getX() + ", " + townHall.getY() + ", " + townHall.getZ() + ") " +
+                                        "chunk (" + townHallChunk.x + ", " + townHallChunk.z + ")"), false);
                     source.sendSuccess(() ->
                         Component.literal("Squadius: " + squadius + " (covers " +
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
                     
-                    LevelChunk chunk = level.getChunk(townHall.x, townHall.z);
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
                     var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
                     if (villageCapability != null) {
                         int villagerCount = villageCapability.getVillagerIds().size();

--- a/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
@@ -227,8 +227,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -295,8 +295,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -338,8 +338,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -389,8 +389,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -449,8 +449,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -492,8 +492,8 @@ public class ZoneCommand {
                         return 0;
                     }
 
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {
@@ -530,25 +530,28 @@ public class ZoneCommand {
                     return 0;
                 }
 
-                ChunkPos townHallPos = village.getTownHallPos();
-                LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                ChunkPos villageChunk = village.getVillageStartingChunk();
+                LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
-                return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
-                    .map(villageCapability -> {
-                        try {
-                            IVillageZone zone = factory.createZone(level);
-                            villageCapability.addZone(zone);
+                var capability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+                if (capability == null) {
+                    source.sendFailure(Component.literal("Village capability not found at chunk " + villageChunk + 
+                        ". The chunk may need to be reloaded. Try leaving and re-entering the area."));
+                    return 0;
+                }
+                
+                try {
+                    IVillageZone zone = factory.createZone(level);
+                    capability.addZone(zone);
 
-                            source.sendSuccess(() ->
-                                Component.literal("Created zone '" + zone.getName() + "' with UUID: " + zone.getUUID()), true);
-                            return 1;
+                    source.sendSuccess(() ->
+                        Component.literal("Created zone '" + zone.getName() + "' with UUID: " + zone.getUUID()), true);
+                    return 1;
 
-                        } catch (Exception e) {
-                            source.sendFailure(Component.literal("Failed to create zone: " + e.getMessage()));
-                            return 0;
-                        }
-                    })
-                    .orElse(0);
+                } catch (Exception e) {
+                    source.sendFailure(Component.literal("Failed to create zone: " + e.getMessage()));
+                    return 0;
+                }
             })
             .orElse(0);
     }
@@ -561,8 +564,8 @@ public class ZoneCommand {
                     return 1;
                 }
 
-                ChunkPos townHallPos = village.getTownHallPos();
-                LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                ChunkPos villageChunk = village.getVillageStartingChunk();
+                LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
 
                 return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                     .map(villageCapability -> {

--- a/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
@@ -56,8 +56,8 @@ public class ZoneUUIDArgument {
                         return Suggestions.empty();
                     }
                     
-                    ChunkPos townHallPos = village.getTownHallPos();
-                    LevelChunk chunk = level.getChunk(townHallPos.x, townHallPos.z);
+                    ChunkPos villageChunk = village.getVillageStartingChunk();
+                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
                     
                     return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
                         .map(villageCapability -> {

--- a/src/main/java/org/sosly/villageworks/data/VillageData.java
+++ b/src/main/java/org/sosly/villageworks/data/VillageData.java
@@ -9,14 +9,15 @@ import java.util.UUID;
 public class VillageData {
     
     private final UUID villageId;
-    private final ChunkPos townHallPos;
+    private final BlockPos townHallPos;
+    private final ChunkPos villageStartingChunk;
     private final int squadius;
     private final String villageName;
-    private BlockPos townHallBlockPos;
     
-    public VillageData(UUID villageId, ChunkPos townHallPos, String villageName, int squadius) {
+    public VillageData(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk, String villageName, int squadius) {
         this.villageId = villageId;
         this.townHallPos = townHallPos;
+        this.villageStartingChunk = villageStartingChunk;
         this.villageName = villageName;
         this.squadius = squadius;
     }
@@ -25,8 +26,12 @@ public class VillageData {
         return villageId;
     }
     
-    public ChunkPos getTownHallPos() {
+    public BlockPos getTownHallPos() {
         return townHallPos;
+    }
+    
+    public ChunkPos getVillageStartingChunk() {
+        return villageStartingChunk;
     }
     
     public String getVillageName() {
@@ -37,21 +42,15 @@ public class VillageData {
         return squadius;
     }
     
-    public BlockPos getTownHallBlockPos() {
-        return townHallBlockPos;
-    }
-    
-    public void setTownHallBlockPos(BlockPos pos) {
-        this.townHallBlockPos = pos;
-    }
     
     public boolean containsChunk(ChunkPos pos) {
         if (pos == null) {
             return false;
         }
         
-        int centerX = townHallPos.x;
-        int centerZ = townHallPos.z;
+        ChunkPos centerChunk = new ChunkPos(townHallPos);
+        int centerX = centerChunk.x;
+        int centerZ = centerChunk.z;
         
         return pos.x >= centerX - squadius &&
                pos.x <= centerX + squadius &&
@@ -68,15 +67,18 @@ public class VillageData {
             return false;
         }
         
-        int thisMinX = townHallPos.x - squadius - minDistance;
-        int thisMaxX = townHallPos.x + squadius + minDistance;
-        int thisMinZ = townHallPos.z - squadius - minDistance;
-        int thisMaxZ = townHallPos.z + squadius + minDistance;
+        ChunkPos thisChunk = new ChunkPos(townHallPos);
+        ChunkPos otherChunk = new ChunkPos(other.townHallPos);
         
-        int otherMinX = other.townHallPos.x - other.squadius;
-        int otherMaxX = other.townHallPos.x + other.squadius;
-        int otherMinZ = other.townHallPos.z - other.squadius;
-        int otherMaxZ = other.townHallPos.z + other.squadius;
+        int thisMinX = thisChunk.x - squadius - minDistance;
+        int thisMaxX = thisChunk.x + squadius + minDistance;
+        int thisMinZ = thisChunk.z - squadius - minDistance;
+        int thisMaxZ = thisChunk.z + squadius + minDistance;
+        
+        int otherMinX = otherChunk.x - other.squadius;
+        int otherMaxX = otherChunk.x + other.squadius;
+        int otherMinZ = otherChunk.z - other.squadius;
+        int otherMaxZ = otherChunk.z + other.squadius;
         
         return thisMinX <= otherMaxX && thisMaxX >= otherMinX &&
                thisMinZ <= otherMaxZ && thisMaxZ >= otherMinZ;
@@ -85,32 +87,28 @@ public class VillageData {
     public CompoundTag serializeNBT() {
         CompoundTag tag = new CompoundTag();
         tag.putString("VillageId", villageId.toString());
-        tag.putLong("TownHallPos", townHallPos.toLong());
+        tag.putLong("TownHallPos", townHallPos.asLong());
+        tag.putLong("VillageStartingChunk", villageStartingChunk.toLong());
         tag.putString("VillageName", villageName);
         tag.putInt("Squadius", squadius);
-        if (townHallBlockPos != null) {
-            tag.putLong("TownHallBlockPos", townHallBlockPos.asLong());
-        }
         return tag;
     }
     
     public static VillageData deserializeNBT(CompoundTag tag) {
         if (!tag.contains("VillageId") || !tag.contains("TownHallPos") ||
-            !tag.contains("VillageName") || !tag.contains("Squadius")) {
+            !tag.contains("VillageStartingChunk") || !tag.contains("VillageName") || 
+            !tag.contains("Squadius")) {
             return null;
         }
         
         try {
             UUID villageId = UUID.fromString(tag.getString("VillageId"));
-            ChunkPos townHallPos = new ChunkPos(tag.getLong("TownHallPos"));
+            BlockPos townHallPos = BlockPos.of(tag.getLong("TownHallPos"));
+            ChunkPos villageStartingChunk = new ChunkPos(tag.getLong("VillageStartingChunk"));
             String villageName = tag.getString("VillageName");
             int squadius = tag.getInt("Squadius");
             
-            VillageData data = new VillageData(villageId, townHallPos, villageName, squadius);
-            if (tag.contains("TownHallBlockPos")) {
-                data.setTownHallBlockPos(BlockPos.of(tag.getLong("TownHallBlockPos")));
-            }
-            return data;
+            return new VillageData(villageId, townHallPos, villageStartingChunk, villageName, squadius);
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -272,8 +272,8 @@ public class Villager extends PathfinderMob {
                 return;
             }
 
-            ChunkPos oldTownHallPos = oldVillage.getTownHallPos();
-            LevelChunk oldChunk = serverLevel.getChunk(oldTownHallPos.x, oldTownHallPos.z);
+            ChunkPos oldVillageChunk = oldVillage.getVillageStartingChunk();
+            LevelChunk oldChunk = serverLevel.getChunk(oldVillageChunk.x, oldVillageChunk.z);
             var oldVillageCapability = oldChunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
             if (oldVillageCapability == null) {
                 return;
@@ -287,8 +287,8 @@ public class Villager extends PathfinderMob {
             return;
         }
 
-        ChunkPos newTownHallPos = newVillage.getTownHallPos();
-        LevelChunk newChunk = serverLevel.getChunk(newTownHallPos.x, newTownHallPos.z);
+        ChunkPos newVillageChunk = newVillage.getVillageStartingChunk();
+        LevelChunk newChunk = serverLevel.getChunk(newVillageChunk.x, newVillageChunk.z);
         var newVillageCapability = newChunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
         if (newVillageCapability == null) {
             return;
@@ -322,8 +322,8 @@ public class Villager extends PathfinderMob {
             return;
         }
 
-        ChunkPos townHallPos = village.getTownHallPos();
-        LevelChunk chunk = serverLevel.getChunk(townHallPos.x, townHallPos.z);
+        ChunkPos villageChunk = village.getVillageStartingChunk();
+        LevelChunk chunk = serverLevel.getChunk(villageChunk.x, villageChunk.z);
         var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
         if (villageCapability != null) {
             villageCapability.removeVillager(this.getUUID());


### PR DESCRIPTION
## Summary
- Separated town hall BlockPos from village capability ChunkPos tracking
- Fixed NPEs when town hall blocks are placed near chunk borders
- Villages now properly track both their physical location and capability storage location

## Changes
- Changed `VillageData.getTownHallPos()` to return BlockPos instead of ChunkPos
- Added `VillageData.getVillageStartingChunk()` to track capability storage location  
- Updated all village lookups to use the correct chunk for capability access
- Updated commands to show both block and chunk positions for clarity

## Known Issue
During testing, discovered that newly created villages require a chunk reload before zones can be added. This is a pre-existing issue that will be addressed separately.

## Testing
- Created new world successfully (no NPE on world creation)
- Placed town hall blocks near chunk borders without errors
- Village info commands display correct positions

Resolves #30