### PR TITLE
Fix villages not working immediately after Town Hall placement

### DIFF
--- a/src/main/java/org/sosly/villageworks/api/capability/IVillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillageCapability.java
@@ -26,16 +26,6 @@ public interface IVillageCapability {
     UUID getVillageId();
     
     /**
-     * @return Position of the Town Hall block
-     */
-    BlockPos getTownHallPos();
-    
-    /**
-     * @return Position of the chunk where this village capability is stored
-     */
-    ChunkPos getVillageStartingChunk();
-    
-    /**
      * @return All zones within this village
      */
     List<IVillageZone> getZones();

--- a/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
@@ -2,7 +2,7 @@ package org.sosly.villageworks.api.capability;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -18,7 +18,7 @@ public interface IVillagesCapability {
      * @param pos Chunk position to check
      * @return Village containing the chunk, or null if no village found
      */
-    VillageData getVillageAt(ChunkPos pos);
+    VillageInfo getVillageAt(ChunkPos pos);
 
     /**
      * Creates a new village with the specified parameters.
@@ -47,19 +47,19 @@ public interface IVillagesCapability {
     /**
      * @return All villages in this dimension
      */
-    Collection<VillageData> getVillages();
+    Collection<VillageInfo> getVillages();
 
     /**
      * Finds a village by its unique identifier.
      * @param villageId UUID to search for
      * @return Village with matching UUID, or null if not found
      */
-    VillageData getVillageById(UUID villageId);
+    VillageInfo getVillageById(UUID villageId);
 
     /**
      * Finds a village by its name.
      * @param villageName Name to search for
      * @return Village with matching name, or null if not found
      */
-    VillageData getVillageByName(String villageName);
+    VillageInfo getVillageByName(String villageName);
 }

--- a/src/main/java/org/sosly/villageworks/api/data/IVillageZone.java
+++ b/src/main/java/org/sosly/villageworks/api/data/IVillageZone.java
@@ -46,6 +46,12 @@ public interface IVillageZone {
     Level getLevel();
     
     /**
+     * Sets the level this zone exists in.
+     * @param level The level to set, must not be null
+     */
+    void setLevel(Level level);
+    
+    /**
      * Returns type-specific points of interest within this zone.
      * Results are cached and only rescanned when zone boundaries change.
      * 

--- a/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.block.entity.TownHallBlockEntity;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 public class TownHallBlock extends BaseEntityBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
@@ -100,7 +100,7 @@ public class TownHallBlock extends BaseEntityBlock {
             return;
         }
         
-        VillageData village = villagesCapability.getVillageById(townHall.getVillageId());
+        VillageInfo village = villagesCapability.getVillageById(townHall.getVillageId());
         if (village != null && pos.equals(village.getTownHallPos())) {
             // Remove the entire village when its town hall is destroyed
             villagesCapability.removeVillage(townHall.getVillageId());

--- a/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
+++ b/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
@@ -8,10 +8,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
 import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.api.capability.IVillageCapability;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.capability.village.VillageCapability;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.util.UUID;
 
@@ -40,14 +43,15 @@ public class TownHallBlockEntity extends BlockEntity {
 
         ChunkPos chunkPos = new ChunkPos(worldPosition);
 
-        serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).ifPresent(villagesCapability ->
-            handleVillageSetup(serverLevel, chunkPos, player, villagesCapability)
-        );
+        IVillagesCapability villagesCapability = serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability != null) {
+            handleVillageSetup(serverLevel, chunkPos, player, villagesCapability);
+        }
     }
 
     private void handleVillageSetup(ServerLevel level, ChunkPos chunkPos, Player player,
                                    IVillagesCapability villagesCapability) {
-        VillageData existingVillage = villagesCapability.getVillageAt(chunkPos);
+        VillageInfo existingVillage = villagesCapability.getVillageAt(chunkPos);
 
         if (existingVillage != null) {
             handleExistingVillage(level, existingVillage, player);
@@ -57,9 +61,9 @@ public class TownHallBlockEntity extends BlockEntity {
         createNewVillage(level, chunkPos, player, villagesCapability);
     }
 
-    private void handleExistingVillage(ServerLevel level, VillageData village, Player player) {
+    private void handleExistingVillage(ServerLevel level, VillageInfo village, Player player) {
         BlockPos existingTownHall = village.getTownHallPos();
-        
+
         VillageWorks.LOGGER.error("Cannot place Town Hall at {} - village {} already has one at {}",
             worldPosition, village.getVillageName(), existingTownHall);
         if (player != null) {
@@ -87,6 +91,13 @@ public class TownHallBlockEntity extends BlockEntity {
         }
 
         setVillageId(newVillageId);
+
+        IVillageCapability cap = level.getChunk(chunkPos.x, chunkPos.z).getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (cap == null) {
+            return;
+        }
+        ((VillageCapability) cap).initializeVillage(newVillageId);
+
         VillageWorks.LOGGER.info("Created village {} at {} with ID {} and town hall at {}",
             villageName, chunkPos, newVillageId, worldPosition);
     }

--- a/src/main/java/org/sosly/villageworks/capability/Capabilities.java
+++ b/src/main/java/org/sosly/villageworks/capability/Capabilities.java
@@ -45,21 +45,12 @@ public class Capabilities {
             return;
         }
         
-        var villageData = villagesCapability.getVillageAt(chunk.getPos());
-        if (villageData == null || !chunk.getPos().equals(villageData.getVillageStartingChunk())) {
-            return;
+        VillageProvider provider = new VillageProvider();
+
+        var villageCap = provider.getCapability(VILLAGE_CAPABILITY, null).orElse(null);
+        if (villageCap instanceof VillageCapability impl) {
+            impl.setOwnerChunk(chunk);
         }
-
-        UUID villageId = villageData.getVillageId();
-        BlockPos townHallPos = villageData.getTownHallPos();
-        VillageProvider provider = new VillageProvider(villageId, townHallPos, chunk.getPos());
-
-        provider.getCapability(VILLAGE_CAPABILITY, null)
-            .ifPresent(cap -> {
-                if (cap instanceof VillageCapability impl) {
-                    impl.setOwnerChunk(chunk);
-                }
-            });
 
         event.addCapability(VILLAGE_CAPABILITY_KEY, provider);
     }
@@ -70,12 +61,10 @@ public class Capabilities {
 
         VillagesProvider provider = new VillagesProvider();
 
-        provider.getCapability(VILLAGES_CAPABILITY, null)
-            .ifPresent(cap -> {
-                if (cap instanceof VillagesCapability impl) {
-                    impl.setOwnerLevel(level);
-                }
-            });
+        var villagesCap = provider.getCapability(VILLAGES_CAPABILITY, null).orElse(null);
+        if (villagesCap instanceof VillagesCapability impl) {
+            impl.setOwnerLevel(level);
+        }
 
         event.addCapability(VILLAGES_CAPABILITY_KEY, provider);
     }

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
@@ -5,48 +5,44 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.sosly.villageworks.api.capability.IVillageCapability;
 import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.data.VillageState;
 
 import java.lang.ref.WeakReference;
 import java.util.*;
+import javax.annotation.Nullable;
 
 public class VillageCapability implements IVillageCapability {
     
-    private final UUID villageId;
-    private final BlockPos townHallPos;
-    private final ChunkPos villageStartingChunk;
-    private final List<IVillageZone> zones;
-    private final Set<UUID> villagerIds;
-    private final Map<UUID, Permission> playerPermissions;
+    @Nullable
+    private VillageState state;
     private WeakReference<LevelChunk> ownerChunk;
     
-    public VillageCapability(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk) {
-        this.villageId = villageId;
-        this.townHallPos = townHallPos;
-        this.villageStartingChunk = villageStartingChunk;
-        this.zones = new ArrayList<>();
-        this.villagerIds = new HashSet<>();
-        this.playerPermissions = new HashMap<>();
+    public VillageCapability() {
+        this.state = null;
         this.ownerChunk = new WeakReference<>(null);
     }
     
     @Override
     public UUID getVillageId() {
-        return villageId;
+        return state != null ? state.getVillageId() : null;
     }
     
     @Override
     public BlockPos getTownHallPos() {
-        return townHallPos;
+        return null; // This should come from VillagesCapability
     }
     
     @Override
     public ChunkPos getVillageStartingChunk() {
-        return villageStartingChunk;
+        return null; // This should come from VillagesCapability
     }
     
     @Override
     public List<IVillageZone> getZones() {
-        return new ModifiableZoneList(zones, this::markDirty);
+        if (state == null) {
+            return Collections.emptyList();
+        }
+        return new ModifiableZoneList(state.getZones(), this::markDirty);
     }
     
     private static class ModifiableZoneList extends ArrayList<IVillageZone> {
@@ -94,29 +90,29 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public void addZone(IVillageZone zone) {
-        if (zone == null) {
+        if (zone == null || state == null) {
             return;
         }
         
-        zones.add(zone);
+        state.addZone(zone);
         markDirty();
     }
     
     public void addZoneWithoutDirty(IVillageZone zone) {
-        if (zone == null) {
+        if (zone == null || state == null) {
             return;
         }
         
-        zones.add(zone);
+        state.addZone(zone);
     }
     
     @Override
     public boolean removeZone(UUID zoneId) {
-        if (zoneId == null) {
+        if (zoneId == null || state == null) {
             return false;
         }
         
-        boolean removed = zones.removeIf(zone -> zoneId.equals(zone.getUUID()));
+        boolean removed = state.getZones().removeIf(zone -> zoneId.equals(zone.getUUID()));
         if (removed) {
             markDirty();
         }
@@ -125,11 +121,11 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public IVillageZone getZoneAt(BlockPos pos) {
-        if (pos == null) {
+        if (pos == null || state == null) {
             return null;
         }
         
-        for (IVillageZone zone : zones) {
+        for (IVillageZone zone : state.getZones()) {
             if (zone.containsPosition(pos)) {
                 return zone;
             }
@@ -139,27 +135,31 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public Set<UUID> getVillagerIds() {
-        return new HashSet<>(villagerIds);
+        if (state == null) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(state.getVillagerIds());
     }
     
     @Override
     public void assignVillager(UUID villagerId) {
-        if (villagerId == null) {
+        if (villagerId == null || state == null) {
             return;
         }
         
-        if (villagerIds.add(villagerId)) {
+        if (!state.getVillagerIds().contains(villagerId)) {
+            state.addVillager(villagerId);
             markDirty();
         }
     }
     
     @Override
     public boolean removeVillager(UUID villagerId) {
-        if (villagerId == null) {
+        if (villagerId == null || state == null) {
             return false;
         }
         
-        boolean removed = villagerIds.remove(villagerId);
+        boolean removed = state.removeVillager(villagerId);
         if (removed) {
             markDirty();
         }
@@ -168,21 +168,25 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public Map<UUID, Permission> getPlayerPermissions() {
-        return new HashMap<>(playerPermissions);
+        if (state == null) {
+            return Collections.emptyMap();
+        }
+        return new HashMap<>(state.getPlayerPermissions());
     }
     
     @Override
     public void setPlayerPermission(UUID playerId, Permission permission) {
-        if (playerId == null || permission == null) {
+        if (playerId == null || permission == null || state == null) {
             return;
         }
         
         if (permission == Permission.NONE) {
-            if (playerPermissions.remove(playerId) != null) {
+            if (state.removePlayerPermission(playerId)) {
                 markDirty();
             }
         } else {
-            Permission oldPermission = playerPermissions.put(playerId, permission);
+            Permission oldPermission = state.getPlayerPermission(playerId);
+            state.setPlayerPermission(playerId, permission);
             if (!permission.equals(oldPermission)) {
                 markDirty();
             }
@@ -191,12 +195,21 @@ public class VillageCapability implements IVillageCapability {
     
     @Override
     public boolean hasPermission(UUID playerId, Permission required) {
-        if (playerId == null || required == null) {
+        if (playerId == null || required == null || state == null) {
             return false;
         }
         
-        Permission playerPermission = playerPermissions.getOrDefault(playerId, Permission.NONE);
+        Permission playerPermission = state.getPlayerPermissions().getOrDefault(playerId, Permission.NONE);
         return playerPermission.ordinal() >= required.ordinal();
+    }
+    
+    public void initializeVillage(UUID villageId) {
+        this.state = new VillageState(villageId);
+        markDirty();
+    }
+    
+    public boolean hasVillage() {
+        return state != null;
     }
     
     public void setOwnerChunk(LevelChunk chunk) {

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageCapability.java
@@ -28,16 +28,6 @@ public class VillageCapability implements IVillageCapability {
     }
     
     @Override
-    public BlockPos getTownHallPos() {
-        return null; // This should come from VillagesCapability
-    }
-    
-    @Override
-    public ChunkPos getVillageStartingChunk() {
-        return null; // This should come from VillagesCapability
-    }
-    
-    @Override
     public List<IVillageZone> getZones() {
         if (state == null) {
             return Collections.emptyList();

--- a/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
+++ b/src/main/java/org/sosly/villageworks/capability/village/VillageProvider.java
@@ -23,8 +23,8 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
     private final VillageCapability capability;
     private final LazyOptional<IVillageCapability> lazyOptional;
 
-    public VillageProvider(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk) {
-        this.capability = new VillageCapability(villageId, townHallPos, villageStartingChunk);
+    public VillageProvider() {
+        this.capability = new VillageCapability();
         this.lazyOptional = LazyOptional.of(() -> capability);
     }
 
@@ -39,11 +39,13 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
 
     @Override
     public CompoundTag serializeNBT() {
+        if (!capability.hasVillage()) {
+            return new CompoundTag();
+        }
+        
         CompoundTag tag = new CompoundTag();
 
         tag.putString("VillageId", capability.getVillageId().toString());
-        tag.putLong("TownHallPos", capability.getTownHallPos().asLong());
-        tag.putLong("VillageStartingChunk", capability.getVillageStartingChunk().toLong());
 
         ListTag villagerList = new ListTag();
         for (UUID villagerId : capability.getVillagerIds()) {
@@ -71,6 +73,10 @@ public class VillageProvider implements ICapabilitySerializable<CompoundTag> {
         if (!tag.hasUUID("VillageId") && !tag.contains("VillageId", Tag.TAG_STRING)) {
             return;
         }
+        
+        UUID villageId = UUID.fromString(tag.getString("VillageId"));
+        
+        capability.initializeVillage(villageId);
 
         // Deserialize villager IDs
         if (tag.contains("VillagerIds", Tag.TAG_LIST)) {

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
@@ -4,14 +4,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.lang.ref.WeakReference;
 import java.util.*;
 
 public class VillagesCapability implements IVillagesCapability {
 
-    private final Map<UUID, VillageData> villages;
+    private final Map<UUID, VillageInfo> villages;
     private final Map<String, UUID> villagesByName;
     private WeakReference<Level> ownerLevel;
 
@@ -22,12 +22,12 @@ public class VillagesCapability implements IVillagesCapability {
     }
 
     @Override
-    public VillageData getVillageAt(ChunkPos pos) {
+    public VillageInfo getVillageAt(ChunkPos pos) {
         if (pos == null) {
             return null;
         }
 
-        for (VillageData village : villages.values()) {
+        for (VillageInfo village : villages.values()) {
             if (village.containsChunk(pos)) {
                 return village;
             }
@@ -51,10 +51,10 @@ public class VillagesCapability implements IVillagesCapability {
 
         UUID villageId = UUID.randomUUID();
         ChunkPos villageStartingChunk = new ChunkPos(townHallPos);
-        VillageData newVillage = new VillageData(villageId, townHallPos, villageStartingChunk, villageName, squadius);
+        VillageInfo newVillage = new VillageInfo(villageId, townHallPos, villageStartingChunk, villageName, squadius);
 
         int minDistance = 30;
-        for (VillageData existingVillage : villages.values()) {
+        for (VillageInfo existingVillage : villages.values()) {
             if (existingVillage.overlaps(newVillage, minDistance)) {
                 return null;
             }
@@ -72,7 +72,7 @@ public class VillagesCapability implements IVillagesCapability {
             return false;
         }
 
-        VillageData village = villages.remove(villageId);
+        VillageInfo village = villages.remove(villageId);
         if (village == null) {
             return false;
         }
@@ -87,7 +87,7 @@ public class VillagesCapability implements IVillagesCapability {
             return false;
         }
 
-        for (VillageData village : villages.values()) {
+        for (VillageInfo village : villages.values()) {
             if (excludeVillageId != null && village.getVillageId().equals(excludeVillageId)) {
                 continue;
             }
@@ -100,12 +100,12 @@ public class VillagesCapability implements IVillagesCapability {
     }
 
     @Override
-    public Collection<VillageData> getVillages() {
+    public Collection<VillageInfo> getVillages() {
         return new ArrayList<>(villages.values());
     }
 
     @Override
-    public VillageData getVillageById(UUID villageId) {
+    public VillageInfo getVillageById(UUID villageId) {
         if (villageId == null) {
             return null;
         }
@@ -113,7 +113,7 @@ public class VillagesCapability implements IVillagesCapability {
     }
 
     @Override
-    public VillageData getVillageByName(String villageName) {
+    public VillageInfo getVillageByName(String villageName) {
         if (villageName == null || villageName.trim().isEmpty()) {
             return null;
         }
@@ -131,7 +131,7 @@ public class VillagesCapability implements IVillagesCapability {
     }
 
 
-    public void loadVillage(VillageData village) {
+    public void loadVillage(VillageInfo village) {
         if (village == null) {
             return;
         }

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesProvider.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesProvider.java
@@ -9,7 +9,7 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +38,7 @@ public class VillagesProvider implements ICapabilitySerializable<CompoundTag> {
         CompoundTag tag = new CompoundTag();
 
         ListTag villageList = new ListTag();
-        for (VillageData village : capability.getVillages()) {
+        for (VillageInfo village : capability.getVillages()) {
             villageList.add(village.serializeNBT());
         }
         tag.put("Villages", villageList);
@@ -55,7 +55,7 @@ public class VillagesProvider implements ICapabilitySerializable<CompoundTag> {
         ListTag villageList = tag.getList("Villages", Tag.TAG_COMPOUND);
         for (int i = 0; i < villageList.size(); i++) {
             CompoundTag villageTag = villageList.getCompound(i);
-            VillageData village = VillageData.deserializeNBT(villageTag);
+            VillageInfo village = VillageInfo.deserializeNBT(villageTag);
             if (village != null) {
                 capability.loadVillage(village);
             }

--- a/src/main/java/org/sosly/villageworks/command/VillageCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillageCommand.java
@@ -12,8 +12,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.capability.village.VillageCapability;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -60,21 +63,30 @@ public class VillageCommand {
             ServerLevel level = source.getLevel();
             BlockPos pos = entity.blockPosition();
 
-            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
-                .map(manager -> {
-                    UUID villageId = manager.createVillage(pos, villageName, squadius);
-                    if (villageId == null) {
-                        source.sendFailure(Component.literal("Failed to create village"));
-                        return 0;
-                    }
+            IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+            if (villages == null) {
+                source.sendFailure(Component.literal("Village not found"));
+                return 0;
+            }
 
-                    source.sendSuccess(() ->
-                        Component.literal("Created village '" + villageName + "' with squadius " + squadius +
-                                        " (covers " + ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), true);
-                    return 1;
-                })
-                .orElse(0);
+            UUID villageId = villages.createVillage(pos, villageName, squadius);
+            if (villageId == null) {
+                source.sendFailure(Component.literal("Village creation failed"));
+                return 0;
+            }
 
+            ChunkPos chunkPos = new ChunkPos(pos);
+            IVillageCapability cap = level.getChunk(chunkPos.x, chunkPos.z).getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+            if (cap == null) {
+                source.sendFailure(Component.literal("Village creation failed"));
+                return 0;
+            }
+            ((VillageCapability) cap).initializeVillage(villageId);
+
+            source.sendSuccess(() ->
+                    Component.literal("Created village '" + villageName + "' with squadius " + squadius +
+                            " (covers " + ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), true);
+            return 1;
         } catch (Exception e) {
             context.getSource().sendFailure(Component.literal("Failed to create village: " + e.getMessage()));
             return 0;
@@ -89,7 +101,7 @@ public class VillageCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageByName(villageName);
+                    VillageInfo village = manager.getVillageByName(villageName);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village '" + villageName + "' not found"));
                         return 0;
@@ -119,7 +131,7 @@ public class VillageCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    Collection<VillageData> villages = manager.getVillages();
+                    Collection<VillageInfo> villages = manager.getVillages();
 
                     if (villages.isEmpty()) {
                         source.sendSuccess(() ->
@@ -130,7 +142,7 @@ public class VillageCommand {
                     source.sendSuccess(() ->
                         Component.literal("Villages in " + level.dimension().location() + ":"), false);
 
-                    for (VillageData village : villages) {
+                    for (VillageInfo village : villages) {
                         BlockPos townHall = village.getTownHallPos();
                         ChunkPos chunkPos = new ChunkPos(townHall);
                         source.sendSuccess(() ->
@@ -165,7 +177,7 @@ public class VillageCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageAt(chunkPos);
+                    VillageInfo village = manager.getVillageAt(chunkPos);
 
                     if (village == null) {
                         source.sendSuccess(() ->
@@ -194,7 +206,7 @@ public class VillageCommand {
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
-                    
+
                     LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
                     var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
                     if (villageCapability != null) {
@@ -212,31 +224,31 @@ public class VillageCommand {
             return 0;
         }
     }
-    
+
     private static int showVillageInfoByName(CommandContext<CommandSourceStack> context) {
         try {
             CommandSourceStack source = context.getSource();
             String villageIdentifier = StringArgumentType.getString(context, "village");
             ServerLevel level = source.getLevel();
-            
+
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village;
-                    
+                    VillageInfo village;
+
                     try {
                         UUID villageId = UUID.fromString(villageIdentifier);
                         village = manager.getVillageById(villageId);
                     } catch (IllegalArgumentException e) {
                         village = manager.getVillageByName(villageIdentifier);
                     }
-                    
+
                     if (village == null) {
                         source.sendFailure(Component.literal("Village '" + villageIdentifier + "' not found"));
                         return 0;
                     }
-                    
-                    final VillageData villageData = village;
-                    
+
+                    final VillageInfo villageData = village;
+
                     BlockPos townHall = villageData.getTownHallPos();
                     ChunkPos townHallChunk = new ChunkPos(townHall);
                     ChunkPos villageChunk = villageData.getVillageStartingChunk();
@@ -245,7 +257,7 @@ public class VillageCommand {
                     int maxX = townHallChunk.x + squadius;
                     int minZ = townHallChunk.z - squadius;
                     int maxZ = townHallChunk.z + squadius;
-                    
+
                     source.sendSuccess(() ->
                         Component.literal("Village: " + villageData.getVillageName()), false);
                     source.sendSuccess(() ->
@@ -258,7 +270,7 @@ public class VillageCommand {
                                         ((squadius * 2 + 1) * (squadius * 2 + 1)) + " chunks)"), false);
                     source.sendSuccess(() ->
                         Component.literal("Boundaries: chunks (" + minX + ", " + minZ + ") to (" + maxX + ", " + maxZ + ")"), false);
-                    
+
                     LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
                     var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
                     if (villageCapability != null) {
@@ -266,11 +278,11 @@ public class VillageCommand {
                         source.sendSuccess(() ->
                             Component.literal("Villagers: " + villagerCount), false);
                     }
-                    
+
                     return 1;
                 })
                 .orElse(0);
-                
+
         } catch (Exception e) {
             context.getSource().sendFailure(Component.literal("Failed to show village info: " + e.getMessage()));
             return 0;

--- a/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
@@ -10,10 +10,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.capability.village.VillageCapability;
 import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 import org.sosly.villageworks.entity.Villager;
 
 import java.util.Collection;
@@ -74,39 +75,38 @@ public class VillagerCommand {
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ServerLevel level = context.getSource().getLevel();
             
-            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
-                .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
-                    if (village == null) {
-                        context.getSource().sendFailure(Component.literal("Village " + villageId + " not found"));
-                        return 0;
-                    }
+            IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+            if (villages == null) {
+                context.getSource().sendFailure(Component.literal("Villages capability not found"));
+                return 0;
+            }
 
-                    int assignedCount = 0;
-                    for (Entity entity : entities) {
-                        if (entity instanceof Villager villager) {
-                            villager.setVillage(villageId);
-                            assignedCount++;
-                        }
-                    }
+            VillageInfo village = villages.getVillageById(villageId);
+            if (village == null) {
+                context.getSource().sendFailure(Component.literal("Village " + villageId + " not found"));
+                return 0;
+            }
 
-                    if (assignedCount == 0) {
-                        context.getSource().sendFailure(Component.literal("No villagers found in selection"));
-                        return 0;
-                    }
+            int assignedCount = 0;
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    villager.setVillage(villageId);
+                    assignedCount++;
+                }
+            }
 
-                    final int finalAssignedCount = assignedCount;
-                    final UUID finalVillageId = villageId;
-                    context.getSource().sendSuccess(() ->
-                        Component.literal(String.format("Assigned %d villager(s) to village %s",
-                            finalAssignedCount, finalVillageId)), true);
+            if (assignedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
 
-                    return assignedCount;
-                })
-                .orElseGet(() -> {
-                    context.getSource().sendFailure(Component.literal("Villages capability not available"));
-                    return 0;
-                });
+            final int finalAssignedCount = assignedCount;
+            final UUID finalVillageId = villageId;
+            context.getSource().sendSuccess(() ->
+                Component.literal(String.format("Assigned %d villager(s) to village %s",
+                    finalAssignedCount, finalVillageId)), true);
+
+            return assignedCount;
 
         } catch (Exception e) {
             context.getSource().sendFailure(Component.literal("Failed to assign village: " + e.getMessage()));

--- a/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
@@ -13,13 +13,15 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.phys.AABB;
+import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.ZoneType;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
 import org.sosly.villageworks.command.arguments.ZoneTypeArgument;
 import org.sosly.villageworks.command.arguments.ZoneUUIDArgument;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 import org.sosly.villageworks.data.zones.PathVillageZone;
 import org.sosly.villageworks.data.zones.ZoneFactory;
 
@@ -28,6 +30,32 @@ import java.util.List;
 import java.util.UUID;
 
 public class ZoneCommand {
+
+    private static IVillageCapability getVillageCapability(CommandSourceStack source, UUID villageId) {
+        ServerLevel level = source.getLevel();
+        
+        IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villages == null) {
+            source.sendFailure(Component.literal("Villages capability not found"));
+            return null;
+        }
+
+        VillageInfo village = villages.getVillageById(villageId);
+        if (village == null) {
+            source.sendFailure(Component.literal("Village not found"));
+            return null;
+        }
+
+        ChunkPos villageChunk = village.getVillageStartingChunk();
+        LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
+        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            source.sendFailure(Component.literal("Village capability not found"));
+            return null;
+        }
+        
+        return villageCapability;
+    }
 
     public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
         parentCommand.then(Commands.literal("zone")
@@ -219,32 +247,20 @@ public class ZoneCommand {
 
             ServerLevel level = source.getLevel();
 
-            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
-                .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
-                    if (village == null) {
-                        source.sendFailure(Component.literal("Village not found"));
-                        return 0;
-                    }
+            IVillageCapability villageCapability = getVillageCapability(source, villageId);
+            if (villageCapability == null) {
+                return 0;
+            }
 
-                    ChunkPos villageChunk = village.getVillageStartingChunk();
-                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
-
-                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
-                        .map(villageCapability -> {
-                            boolean removed = villageCapability.removeZone(zoneId);
-                            if (removed) {
-                                source.sendSuccess(() ->
-                                    Component.literal("Deleted zone " + zoneId), true);
-                                return 1;
-                            } else {
-                                source.sendFailure(Component.literal("Zone not found in village"));
-                                return 0;
-                            }
-                        })
-                        .orElse(0);
-                })
-                .orElse(0);
+            boolean removed = villageCapability.removeZone(zoneId);
+            if (removed) {
+                source.sendSuccess(() ->
+                    Component.literal("Deleted zone " + zoneId), true);
+                return 1;
+            } else {
+                source.sendFailure(Component.literal("Zone not found in village"));
+                return 0;
+            }
 
         } catch (Exception e) {
             context.getSource().sendFailure(Component.literal("Failed to delete zone: " + e.getMessage()));
@@ -289,7 +305,7 @@ public class ZoneCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
+                    VillageInfo village = manager.getVillageById(villageId);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village not found"));
                         return 0;
@@ -332,7 +348,7 @@ public class ZoneCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
+                    VillageInfo village = manager.getVillageById(villageId);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village not found"));
                         return 0;
@@ -383,7 +399,7 @@ public class ZoneCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
+                    VillageInfo village = manager.getVillageById(villageId);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village not found"));
                         return 0;
@@ -443,7 +459,7 @@ public class ZoneCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
+                    VillageInfo village = manager.getVillageById(villageId);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village not found"));
                         return 0;
@@ -486,7 +502,7 @@ public class ZoneCommand {
 
             return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
+                    VillageInfo village = manager.getVillageById(villageId);
                     if (village == null) {
                         source.sendFailure(Component.literal("Village not found"));
                         return 0;
@@ -524,7 +540,7 @@ public class ZoneCommand {
 
         return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
             .map(manager -> {
-                VillageData village = manager.getVillageById(villageId);
+                VillageInfo village = manager.getVillageById(villageId);
                 if (village == null) {
                     source.sendFailure(Component.literal("Village not found"));
                     return 0;
@@ -559,7 +575,7 @@ public class ZoneCommand {
     private static int getNextZoneId(ServerLevel level, UUID villageId) {
         return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
             .map(manager -> {
-                VillageData village = manager.getVillageById(villageId);
+                VillageInfo village = manager.getVillageById(villageId);
                 if (village == null) {
                     return 1;
                 }

--- a/src/main/java/org/sosly/villageworks/command/arguments/VillageUUIDArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/VillageUUIDArgument.java
@@ -11,8 +11,9 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -41,15 +42,16 @@ public class VillageUUIDArgument {
     public static CompletableFuture<Suggestions> suggest(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
         ServerLevel level = context.getSource().getLevel();
         
-        return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
-            .map(manager -> {
-                Collection<VillageData> villages = manager.getVillages();
-                Collection<String> villageUUIDs = villages.stream()
-                    .map(village -> village.getVillageId().toString())
-                    .collect(Collectors.toList());
-                
-                return SharedSuggestionProvider.suggest(villageUUIDs, builder);
-            })
-            .orElse(Suggestions.empty());
+        IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villages == null) {
+            return Suggestions.empty();
+        }
+
+        Collection<VillageInfo> villageInfos = villages.getVillages();
+        Collection<String> villageUUIDs = villageInfos.stream()
+            .map(village -> village.getVillageId().toString())
+            .collect(Collectors.toList());
+        
+        return SharedSuggestionProvider.suggest(villageUUIDs, builder);
     }
 }

--- a/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
+++ b/src/main/java/org/sosly/villageworks/command/arguments/ZoneUUIDArgument.java
@@ -13,9 +13,11 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import java.util.Collection;
 import java.util.List;
@@ -49,28 +51,29 @@ public class ZoneUUIDArgument {
             
             ServerLevel level = context.getSource().getLevel();
             
-            return level.getCapability(Capabilities.VILLAGES_CAPABILITY)
-                .map(manager -> {
-                    VillageData village = manager.getVillageById(villageId);
-                    if (village == null) {
-                        return Suggestions.empty();
-                    }
-                    
-                    ChunkPos villageChunk = village.getVillageStartingChunk();
-                    LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
-                    
-                    return chunk.getCapability(Capabilities.VILLAGE_CAPABILITY)
-                        .map(villageCapability -> {
-                            List<IVillageZone> zones = villageCapability.getZones();
-                            Collection<String> zoneUUIDs = zones.stream()
-                                .map(zone -> zone.getUUID().toString())
-                                .collect(Collectors.toList());
-                            
-                            return SharedSuggestionProvider.suggest(zoneUUIDs, builder);
-                        })
-                        .orElse(Suggestions.empty());
-                })
-                .orElse(Suggestions.empty());
+            IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+            if (villages == null) {
+                return Suggestions.empty();
+            }
+
+            VillageInfo village = villages.getVillageById(villageId);
+            if (village == null) {
+                return Suggestions.empty();
+            }
+            
+            ChunkPos villageChunk = village.getVillageStartingChunk();
+            LevelChunk chunk = level.getChunk(villageChunk.x, villageChunk.z);
+            IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+            if (villageCapability == null) {
+                return Suggestions.empty();
+            }
+
+            List<IVillageZone> zones = villageCapability.getZones();
+            Collection<String> zoneUUIDs = zones.stream()
+                .map(zone -> zone.getUUID().toString())
+                .collect(Collectors.toList());
+            
+            return SharedSuggestionProvider.suggest(zoneUUIDs, builder);
         } catch (Exception e) {
             return Suggestions.empty();
         }

--- a/src/main/java/org/sosly/villageworks/data/VillageInfo.java
+++ b/src/main/java/org/sosly/villageworks/data/VillageInfo.java
@@ -6,7 +6,7 @@ import net.minecraft.world.level.ChunkPos;
 
 import java.util.UUID;
 
-public class VillageData {
+public class VillageInfo {
     
     private final UUID villageId;
     private final BlockPos townHallPos;
@@ -14,7 +14,7 @@ public class VillageData {
     private final int squadius;
     private final String villageName;
     
-    public VillageData(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk, String villageName, int squadius) {
+    public VillageInfo(UUID villageId, BlockPos townHallPos, ChunkPos villageStartingChunk, String villageName, int squadius) {
         this.villageId = villageId;
         this.townHallPos = townHallPos;
         this.villageStartingChunk = villageStartingChunk;
@@ -58,11 +58,11 @@ public class VillageData {
                pos.z <= centerZ + squadius;
     }
     
-    public boolean overlaps(VillageData other) {
+    public boolean overlaps(VillageInfo other) {
         return overlaps(other, 0);
     }
     
-    public boolean overlaps(VillageData other, int minDistance) {
+    public boolean overlaps(VillageInfo other, int minDistance) {
         if (other == null) {
             return false;
         }
@@ -94,7 +94,7 @@ public class VillageData {
         return tag;
     }
     
-    public static VillageData deserializeNBT(CompoundTag tag) {
+    public static VillageInfo deserializeNBT(CompoundTag tag) {
         if (!tag.contains("VillageId") || !tag.contains("TownHallPos") ||
             !tag.contains("VillageStartingChunk") || !tag.contains("VillageName") || 
             !tag.contains("Squadius")) {
@@ -108,7 +108,7 @@ public class VillageData {
             String villageName = tag.getString("VillageName");
             int squadius = tag.getInt("Squadius");
             
-            return new VillageData(villageId, townHallPos, villageStartingChunk, villageName, squadius);
+            return new VillageInfo(villageId, townHallPos, villageStartingChunk, villageName, squadius);
         } catch (IllegalArgumentException e) {
             return null;
         }
@@ -123,7 +123,7 @@ public class VillageData {
             return false;
         }
         
-        VillageData other = (VillageData) obj;
+        VillageInfo other = (VillageInfo) obj;
         return villageId.equals(other.villageId);
     }
     

--- a/src/main/java/org/sosly/villageworks/data/VillageState.java
+++ b/src/main/java/org/sosly/villageworks/data/VillageState.java
@@ -1,0 +1,75 @@
+package org.sosly.villageworks.data;
+
+import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.data.IVillageZone;
+
+import java.util.*;
+
+public class VillageState {
+    
+    private final UUID villageId;
+    private final List<IVillageZone> zones;
+    private final Set<UUID> villagerIds;
+    private final Map<UUID, IVillageCapability.Permission> playerPermissions;
+    
+    public VillageState(UUID villageId) {
+        this.villageId = villageId;
+        this.zones = new ArrayList<>();
+        this.villagerIds = new HashSet<>();
+        this.playerPermissions = new HashMap<>();
+    }
+    
+    public UUID getVillageId() {
+        return villageId;
+    }
+    
+    public List<IVillageZone> getZones() {
+        return zones;
+    }
+    
+    public Set<UUID> getVillagerIds() {
+        return villagerIds;
+    }
+    
+    public Map<UUID, IVillageCapability.Permission> getPlayerPermissions() {
+        return playerPermissions;
+    }
+    
+    public void addZone(IVillageZone zone) {
+        if (zone != null) {
+            zones.add(zone);
+        }
+    }
+    
+    public boolean removeZone(IVillageZone zone) {
+        return zones.remove(zone);
+    }
+    
+    public void addVillager(UUID villagerId) {
+        if (villagerId != null) {
+            villagerIds.add(villagerId);
+        }
+    }
+    
+    public boolean removeVillager(UUID villagerId) {
+        return villagerIds.remove(villagerId);
+    }
+    
+    public void setPlayerPermission(UUID playerId, IVillageCapability.Permission permission) {
+        if (playerId != null && permission != null) {
+            playerPermissions.put(playerId, permission);
+        }
+    }
+    
+    public IVillageCapability.Permission getPlayerPermission(UUID playerId) {
+        return playerPermissions.get(playerId);
+    }
+    
+    public boolean removePlayerPermission(UUID playerId) {
+        return playerPermissions.remove(playerId) != null;
+    }
+    
+    public boolean isEmpty() {
+        return zones.isEmpty() && villagerIds.isEmpty() && playerPermissions.isEmpty();
+    }
+}

--- a/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
+++ b/src/main/java/org/sosly/villageworks/data/zones/ZoneFactory.java
@@ -1,6 +1,7 @@
 package org.sosly.villageworks.data.zones;
 
-import net.minecraft.client.Minecraft;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -95,9 +96,6 @@ public class ZoneFactory {
             IVillageZone zone = createZone(shape, uuid, type, id, name);
             zone.deserializeNBT(tag);
 
-            if (!(zone instanceof AbstractVillageZone abstractZone)) {
-                return zone;
-            }
             if (!tag.contains("Level")) {
                 return zone;
             }
@@ -106,12 +104,13 @@ public class ZoneFactory {
             ResourceLocation dimensionId = new ResourceLocation(levelKey);
             ResourceKey<Level> levelResourceKey = ResourceKey.create(Registries.DIMENSION, dimensionId);
 
-            Level level = Minecraft.getInstance().level.getServer().getLevel(levelResourceKey);
+            MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+            Level level = server != null ? server.getLevel(levelResourceKey) : null;
             if (level == null) {
                 return zone;
             }
 
-            abstractZone.setLevel(level);
+            zone.setLevel(level);
             return zone;
 
         } catch (Exception e) {

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -43,7 +43,7 @@ import org.sosly.villageworks.entity.ai.behavior.VillagerGoalPackages;
 import org.sosly.villageworks.entity.ai.SensorTypes;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.capability.village.VillageCapability;
-import org.sosly.villageworks.data.VillageData;
+import org.sosly.villageworks.data.VillageInfo;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -267,7 +267,7 @@ public class Villager extends PathfinderMob {
         }
 
         if (currentVillageId.isPresent()) {
-            VillageData oldVillage = villages.getVillageById(currentVillageId.get());
+            VillageInfo oldVillage = villages.getVillageById(currentVillageId.get());
             if (oldVillage == null) {
                 return;
             }
@@ -282,7 +282,7 @@ public class Villager extends PathfinderMob {
             oldVillageCapability.removeVillager(this.getUUID());
         }
 
-        VillageData newVillage = villages.getVillageById(villageId);
+        VillageInfo newVillage = villages.getVillageById(villageId);
         if (newVillage == null) {
             return;
         }
@@ -316,7 +316,7 @@ public class Villager extends PathfinderMob {
             return;
         }
 
-        VillageData village = manager.getVillageById(currentVillageId.get());
+        VillageInfo village = manager.getVillageById(currentVillageId.get());
         if (village == null) {
             this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
             return;


### PR DESCRIPTION
# Fix villages not working immediately after Town Hall placement
Resolves the issue where players couldn't create zones or perform village operations immediately after placing a Town Hall block without forcing a chunk reload.

## Changes
- Split `VillageData` into `VillageInfo` (global metadata) and `VillageState` (chunk-local content)
- Attach `VillageCapability` to all chunks with nullable `VillageState` for lightweight empty capabilities
- Initialize village state immediately when Town Hall is placed via `initializeVillage()` 
- Add `setLevel()` method to `IVillageZone` interface to eliminate type casting in `ZoneFactory`
- Empty capabilities use minimal memory (~8 bytes) and serialize to empty NBT

## Related Issues
Fixes #33

## Implementation Notes
Universal VillageCapabilities ensure villages work immediately on creation since the capability is already present. Empty capabilities remain lightweight and don't impact performance or save file size.

## Breaking Changes
None - existing village data migrates transparently through the VillageInfo rename.