### PR TITLE
feat: implement FindFoodInStorage behavior for villagers

### DIFF
--- a/src/main/java/org/sosly/villageworks/entity/FakePlayer.java
+++ b/src/main/java/org/sosly/villageworks/entity/FakePlayer.java
@@ -1,0 +1,33 @@
+package org.sosly.villageworks.entity;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Abilities;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameType;
+
+import java.util.UUID;
+
+public class FakePlayer extends Player {
+    private static final GameProfile FAKE_PROFILE = new GameProfile(UUID.fromString("00000000-0000-0000-0000-000000000000"), "[VillageWorks]");
+
+    public FakePlayer(ServerLevel level) {
+        super(level, BlockPos.ZERO, 0.0F, FAKE_PROFILE);
+    }
+
+    @Override
+    public boolean isSpectator() {
+        return false;
+    }
+
+    @Override
+    public boolean isCreative() {
+        return false;
+    }
+
+}

--- a/src/main/java/org/sosly/villageworks/entity/FakePlayer.java
+++ b/src/main/java/org/sosly/villageworks/entity/FakePlayer.java
@@ -14,10 +14,9 @@ import net.minecraft.world.level.GameType;
 import java.util.UUID;
 
 public class FakePlayer extends Player {
-    private static final GameProfile FAKE_PROFILE = new GameProfile(UUID.fromString("00000000-0000-0000-0000-000000000000"), "[VillageWorks]");
 
     public FakePlayer(ServerLevel level) {
-        super(level, BlockPos.ZERO, 0.0F, FAKE_PROFILE);
+        super(level, BlockPos.ZERO, 0.0F, new GameProfile(UUID.randomUUID(), "[VillageWorks]"));
     }
 
     @Override

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
@@ -1,0 +1,185 @@
+package org.sosly.villageworks.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villageworks.api.capability.IVillageCapability;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.ZoneType;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.VillageInfo;
+import org.sosly.villageworks.entity.MemoryModuleTypes;
+import org.sosly.villageworks.entity.Villager;
+import org.sosly.villageworks.helper.ContainerHelper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class FindFoodInStorageBehavior extends Behavior<Villager> {
+    private static final int BEHAVIOR_DURATION = 100;
+    private static final double INTERACTION_DISTANCE = 2.0D;
+    private static final int SEARCH_DURATION = 20; // 1 second at 20 tps
+    
+    private BlockPos targetContainer;
+    private boolean searchingForFood;
+    private boolean atContainer;
+    private int searchTicks;
+
+    public FindFoodInStorageBehavior() {
+        super(ImmutableMap.of(
+            MemoryModuleTypes.IS_HUNGRY.get(), MemoryStatus.VALUE_PRESENT,
+            MemoryModuleTypes.VILLAGE.get(), MemoryStatus.VALUE_PRESENT
+        ), BEHAVIOR_DURATION);
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        Boolean isHungry = villager.getBrain().getMemory(MemoryModuleTypes.IS_HUNGRY.get()).orElse(false);
+        if (!isHungry) {
+            return false;
+        }
+
+        if (!villager.getInventory().getItem(0).isEmpty()) {
+            return false;
+        }
+
+        UUID villageId = villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null);
+        if (villageId == null) {
+            return false;
+        }
+
+        BlockPos nearestFood = findNearestStorageWithFood(level, villager, villageId);
+        if (nearestFood == null) {
+            return false;
+        }
+
+        this.targetContainer = nearestFood;
+        return true;
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        this.searchingForFood = true;
+        this.atContainer = false;
+        this.searchTicks = 0;
+        villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET, 
+            new WalkTarget(this.targetContainer, 0.5F, 1));
+    }
+
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        if (!this.searchingForFood) {
+            return false;
+        }
+
+        Boolean isHungry = villager.getBrain().getMemory(MemoryModuleTypes.IS_HUNGRY.get()).orElse(false);
+        return isHungry && villager.getInventory().getItem(0).isEmpty();
+    }
+
+    @Override
+    protected void tick(ServerLevel level, Villager villager, long gameTime) {
+        if (this.targetContainer == null) {
+            return;
+        }
+
+        if (!villager.blockPosition().closerThan(this.targetContainer, INTERACTION_DISTANCE)) {
+            return;
+        }
+
+        if (!this.atContainer) {
+            this.atContainer = true;
+            this.searchTicks = 0;
+            ContainerHelper.openContainer(level, this.targetContainer);
+            villager.getBrain().eraseMemory(MemoryModuleType.WALK_TARGET);
+            return;
+        }
+        
+        this.searchTicks++;
+        
+        if (this.searchTicks >= SEARCH_DURATION) {
+            ItemStack extractedFood = ContainerHelper.extractItemFromContainer(level, this.targetContainer, FindFoodInStorageBehavior::isFood);
+            if (!extractedFood.isEmpty()) {
+                villager.getInventory().setItem(0, extractedFood);
+            }
+            this.searchingForFood = false;
+        }
+    }
+
+    @Override
+    protected void stop(ServerLevel level, Villager villager, long gameTime) {
+        this.targetContainer = null;
+        this.searchingForFood = false;
+        this.atContainer = false;
+        this.searchTicks = 0;
+        villager.getBrain().eraseMemory(MemoryModuleType.WALK_TARGET);
+    }
+
+    private BlockPos findNearestStorageWithFood(ServerLevel level, Villager villager, UUID villageId) {
+        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return null;
+        }
+
+        VillageInfo village = villagesCapability.getVillageById(villageId);
+        if (village == null) {
+            return null;
+        }
+
+        ChunkPos townHallChunk = new ChunkPos(village.getTownHallPos());
+        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
+        
+        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            return null;
+        }
+
+        List<IVillageZone> zones = villageCapability.getZones();
+        BlockPos villagerPos = villager.blockPosition();
+        BlockPos nearestContainer = null;
+        double nearestDistance = Double.MAX_VALUE;
+
+        for (IVillageZone zone : zones) {
+            if (zone.getType() != ZoneType.STORAGE) {
+                continue;
+            }
+
+            Optional<List<BlockPos>> pois = zone.getPOIs();
+            if (!pois.isPresent()) {
+                continue;
+            }
+
+            for (BlockPos containerPos : pois.get()) {
+                if (!ContainerHelper.hasMatchingItem(level, containerPos, FindFoodInStorageBehavior::isFood)) {
+                    continue;
+                }
+                
+                double distance = villagerPos.distSqr(containerPos);
+                if (distance < nearestDistance) {
+                    nearestDistance = distance;
+                    nearestContainer = containerPos;
+                }
+            }
+        }
+
+        return nearestContainer;
+    }
+
+    private static boolean isFood(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+        return stack.getFoodProperties(null) != null;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerGoalPackages.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/VillagerGoalPackages.java
@@ -29,6 +29,7 @@ public class VillagerGoalPackages {
             Pair.of(1, (BehaviorControl<? super Villager>) new MoveToTargetSink()),
             Pair.of(1, WakeUp.create()),
             Pair.of(2, (BehaviorControl<? super Villager>) new EatFood()),
+            Pair.of(3, (BehaviorControl<? super Villager>) new FindFoodInStorageBehavior()),
             Pair.of(99, (BehaviorControl<? super Villager>) UpdateActivityFromSchedule.create())
         );
     }

--- a/src/main/java/org/sosly/villageworks/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villageworks/helper/ContainerHelper.java
@@ -1,0 +1,105 @@
+package org.sosly.villageworks.helper;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import org.sosly.villageworks.entity.FakePlayer;
+
+import java.util.function.Predicate;
+
+public class ContainerHelper {
+
+    private static FakePlayer globalFakePlayer;
+
+    public static void openContainer(ServerLevel level, BlockPos containerPos) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container)) {
+            return;
+        }
+
+        level.blockEvent(containerPos, level.getBlockState(containerPos).getBlock(), 1, 1);
+
+        if (blockEntity instanceof RandomizableContainerBlockEntity container) {
+            if (globalFakePlayer == null) {
+                globalFakePlayer = new FakePlayer(level);
+            }
+            container.startOpen(globalFakePlayer);
+        }
+    }
+
+    public static void closeContainer(ServerLevel level, BlockPos containerPos) {
+        // Don't call this method - containers auto-close when FakePlayer isn't in world
+        // ContainerOpenersCounter.recheckOpeners() finds no real players and closes automatically
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container)) {
+            return;
+        }
+
+        level.blockEvent(containerPos, level.getBlockState(containerPos).getBlock(), 1, 0);
+
+        if (blockEntity instanceof RandomizableContainerBlockEntity container) {
+            if (globalFakePlayer == null) {
+                globalFakePlayer = new FakePlayer(level);
+            }
+            container.stopOpen(globalFakePlayer);
+        }
+    }
+
+    public static ItemStack extractItemFromContainer(ServerLevel level, BlockPos containerPos, Predicate<ItemStack> itemMatcher) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return ItemStack.EMPTY;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack stack = container.getItem(i);
+            if (itemMatcher.test(stack)) {
+                ItemStack extracted = stack.copy();
+                extracted.setCount(1);
+                stack.shrink(1);
+                container.setChanged();
+                return extracted;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    public static ItemStack extractItemFromContainer(ServerLevel level, BlockPos containerPos, ItemStack targetItem) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return ItemStack.EMPTY;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack stack = container.getItem(i);
+            if (ItemStack.isSameItem(stack, targetItem)) {
+                ItemStack extracted = stack.copy();
+                extracted.setCount(Math.min(extracted.getCount(), targetItem.getCount()));
+                stack.shrink(extracted.getCount());
+                container.setChanged();
+                return extracted;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    public static boolean hasMatchingItem(ServerLevel level, BlockPos containerPos, Predicate<ItemStack> itemMatcher) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return false;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack stack = container.getItem(i);
+            if (itemMatcher.test(stack)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+}

--- a/src/main/java/org/sosly/villageworks/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villageworks/helper/ContainerHelper.java
@@ -12,8 +12,6 @@ import java.util.function.Predicate;
 
 public class ContainerHelper {
 
-    private static FakePlayer globalFakePlayer;
-
     public static void openContainer(ServerLevel level, BlockPos containerPos) {
         BlockEntity blockEntity = level.getBlockEntity(containerPos);
         if (!(blockEntity instanceof Container)) {
@@ -23,10 +21,8 @@ public class ContainerHelper {
         level.blockEvent(containerPos, level.getBlockState(containerPos).getBlock(), 1, 1);
 
         if (blockEntity instanceof RandomizableContainerBlockEntity container) {
-            if (globalFakePlayer == null) {
-                globalFakePlayer = new FakePlayer(level);
-            }
-            container.startOpen(globalFakePlayer);
+            FakePlayer fakePlayer = new FakePlayer(level);
+            container.startOpen(fakePlayer);
         }
     }
 
@@ -41,10 +37,8 @@ public class ContainerHelper {
         level.blockEvent(containerPos, level.getBlockState(containerPos).getBlock(), 1, 0);
 
         if (blockEntity instanceof RandomizableContainerBlockEntity container) {
-            if (globalFakePlayer == null) {
-                globalFakePlayer = new FakePlayer(level);
-            }
-            container.stopOpen(globalFakePlayer);
+            FakePlayer fakePlayer = new FakePlayer(level);
+            container.stopOpen(fakePlayer);
         }
     }
 


### PR DESCRIPTION
# Add villager food storage behavior
Implements food-seeking behavior for hungry villagers, allowing them to search storage zones and retrieve food items.

## Changes
- **FindFoodInStorageBehavior**: Core behavior enabling villagers to locate and extract food from village storage containers
- **ContainerHelper**: Reusable utility class for container interactions with predicate-based item matching
- **FakePlayer**: Minimal Player implementation to trigger vanilla container opening animations and sounds
- **Integration**: Added behavior to villager core package with priority 3 (after eating, before other activities)

## Implementation Details
- Villagers search village storage zones for containers containing food items
- Pathfinding to nearest container with food using WalkTarget memory
- Container opening with visual/audio feedback via FakePlayer mechanism
- Single item extraction to villager inventory slot 0
- Automatic container closing via vanilla ContainerOpenersCounter mechanics

## Testing
- [x] Hungry villagers with village assignment seek food from storage containers
- [x] Container opening plays animation and sound effects
- [x] Food extraction works correctly with inventory updates
- [x] Behavior integrates with existing EatFood system
- [x] Containers auto-close after interaction

## Technical Notes
Container auto-closing occurs because FakePlayer isn't added to world entity list, causing ContainerOpenersCounter.recheckOpeners() to find zero real players and trigger closure. This is acceptable behavior for the current implementation.

Resolves #21