### PR TITLE
Town Hall Zone Auto-Management

### DIFF
--- a/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/api/capability/IVillagesCapability.java
@@ -62,4 +62,12 @@ public interface IVillagesCapability {
      * @return Village with matching name, or null if not found
      */
     VillageInfo getVillageByName(String villageName);
+
+    /**
+     * Updates the town hall position for a village.
+     * @param villageId UUID of village to update
+     * @param newPos New position for the town hall, or null to clear
+     * @return true if village was found and updated
+     */
+    boolean updateTownHallPos(UUID villageId, BlockPos newPos);
 }

--- a/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.api.data.ZoneType;
 import org.sosly.villageworks.block.entity.TownHallBlockEntity;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.data.VillageInfo;
@@ -144,7 +145,7 @@ public class TownHallBlock extends BaseEntityBlock {
         var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
         if (villageCapability != null) {
             var zones = villageCapability.getZones();
-            zones.removeIf(zone -> zone.getType() == org.sosly.villageworks.api.data.ZoneType.TOWNHALL);
+            zones.removeIf(zone -> zone.getType() == ZoneType.TOWNHALL);
             VillageWorks.LOGGER.info("Removed TOWNHALL zone from village {}", village.getVillageName());
         }
     }

--- a/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villageworks/block/TownHallBlock.java
@@ -28,9 +28,11 @@ import org.sosly.villageworks.block.entity.TownHallBlockEntity;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.data.VillageInfo;
 
+import java.util.UUID;
+
 public class TownHallBlock extends BaseEntityBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
-    
+
     private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);
 
     public TownHallBlock(Properties properties) {
@@ -80,39 +82,46 @@ public class TownHallBlock extends BaseEntityBlock {
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        super.onRemove(state, level, pos, newState, isMoving);
-        
         if (state.is(newState.getBlock()) || level.isClientSide) {
+            super.onRemove(state, level, pos, newState, isMoving);
             return;
         }
-        
+
         BlockEntity blockEntity = level.getBlockEntity(pos);
-        if (!(blockEntity instanceof TownHallBlockEntity townHall)) {
+        if (!(blockEntity instanceof TownHallBlockEntity townHall) || !(level instanceof ServerLevel serverLevel)) {
+            super.onRemove(state, level, pos, newState, isMoving);
             return;
         }
-        
-        if (townHall.getVillageId() == null || !(level instanceof ServerLevel serverLevel)) {
+
+        UUID villageId = townHall.getVillageId();
+        if (villageId == null) {
+            super.onRemove(state, level, pos, newState, isMoving);
             return;
         }
-        
+
         var villagesCapability = serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
         if (villagesCapability == null) {
+            super.onRemove(state, level, pos, newState, isMoving);
             return;
         }
-        
-        VillageInfo village = villagesCapability.getVillageById(townHall.getVillageId());
-        if (village != null && pos.equals(village.getTownHallPos())) {
-            // Remove the entire village when its town hall is destroyed
-            villagesCapability.removeVillage(townHall.getVillageId());
-            VillageWorks.LOGGER.info("Removed village {} after town hall destruction at {}", 
-                village.getVillageName(), pos);
+
+        VillageInfo village = villagesCapability.getVillageById(villageId);
+        if (village == null) {
+            super.onRemove(state, level, pos, newState, isMoving);
+            return;
         }
+
+        village.setTownHallPos(null);
+        removeTownHallZone(serverLevel, village);
+        VillageWorks.LOGGER.info("Removed town hall at {} from village {}", pos, village.getVillageName());
+
+        super.onRemove(state, level, pos, newState, isMoving);
     }
 
     @Override
     public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable net.minecraft.world.entity.LivingEntity placer, net.minecraft.world.item.ItemStack stack) {
         super.setPlacedBy(level, pos, state, placer, stack);
-        
+
         if (level.isClientSide || !(placer instanceof Player player)) {
             return;
         }
@@ -128,5 +137,15 @@ public class TownHallBlock extends BaseEntityBlock {
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new TownHallBlockEntity(pos, state);
+    }
+
+    private void removeTownHallZone(ServerLevel level, VillageInfo village) {
+        var chunk = level.getChunk(village.getVillageStartingChunk().x, village.getVillageStartingChunk().z);
+        var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability != null) {
+            var zones = villageCapability.getZones();
+            zones.removeIf(zone -> zone.getType() == org.sosly.villageworks.api.data.ZoneType.TOWNHALL);
+            VillageWorks.LOGGER.info("Removed TOWNHALL zone from village {}", village.getVillageName());
+        }
     }
 }

--- a/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
+++ b/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
@@ -12,6 +12,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.api.capability.IVillageCapability;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.api.data.ZoneType;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.capability.village.VillageCapability;
 import org.sosly.villageworks.data.VillageInfo;
@@ -149,10 +150,10 @@ public class TownHallBlockEntity extends BlockEntity {
         }
 
         var zones = villageCapability.getZones();
-        zones.removeIf(zone -> zone.getType() == org.sosly.villageworks.api.data.ZoneType.TOWNHALL);
+        zones.removeIf(zone -> zone.getType() == ZoneType.TOWNHALL);
         
         var townHallZone = ZoneFactory.createBlockPosZone(
-            org.sosly.villageworks.api.data.ZoneType.TOWNHALL,
+            ZoneType.TOWNHALL,
             getNextZoneId(villageCapability),
             "Town Hall",
             worldPosition,

--- a/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
+++ b/src/main/java/org/sosly/villageworks/block/entity/TownHallBlockEntity.java
@@ -15,6 +15,7 @@ import org.sosly.villageworks.api.capability.IVillagesCapability;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.capability.village.VillageCapability;
 import org.sosly.villageworks.data.VillageInfo;
+import org.sosly.villageworks.data.zones.ZoneFactory;
 
 import java.util.UUID;
 
@@ -64,13 +65,29 @@ public class TownHallBlockEntity extends BlockEntity {
     private void handleExistingVillage(ServerLevel level, VillageInfo village, Player player) {
         BlockPos existingTownHall = village.getTownHallPos();
 
-        VillageWorks.LOGGER.error("Cannot place Town Hall at {} - village {} already has one at {}",
-            worldPosition, village.getVillageName(), existingTownHall);
-        if (player != null) {
-            player.sendSystemMessage(Component.translatable("villageworks.townhall.already_exists",
-                village.getVillageName(), existingTownHall.toShortString()));
+        if (existingTownHall != null) {
+            VillageWorks.LOGGER.error("Cannot place Town Hall at {} - village {} already has one at {}", worldPosition, village.getVillageName(), existingTownHall);
+            if (player != null) {
+                player.sendSystemMessage(Component.translatable("villageworks.townhall.already_exists", village.getVillageName(), existingTownHall.toShortString()));
+            }
+            level.destroyBlock(worldPosition, true);
+            return;
         }
-        level.destroyBlock(worldPosition, true);
+
+        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return;
+        }
+
+        villagesCapability.updateTownHallPos(village.getVillageId(), worldPosition);
+        setVillageId(village.getVillageId());
+        createTownHallZone(level, village);
+
+        VillageWorks.LOGGER.info("Added town hall for village {} at {}", village.getVillageName(), worldPosition);
+        
+        if (player != null) {
+            player.sendSystemMessage(Component.literal("Added town hall for village " + village.getVillageName()));
+        }
     }
 
     private void createNewVillage(ServerLevel level, ChunkPos chunkPos, Player player,
@@ -98,6 +115,11 @@ public class TownHallBlockEntity extends BlockEntity {
         }
         ((VillageCapability) cap).initializeVillage(newVillageId);
 
+        VillageInfo village = villagesCapability.getVillageById(newVillageId);
+        if (village != null) {
+            createTownHallZone(level, village);
+        }
+
         VillageWorks.LOGGER.info("Created village {} at {} with ID {} and town hall at {}",
             villageName, chunkPos, newVillageId, worldPosition);
     }
@@ -117,5 +139,31 @@ public class TownHallBlockEntity extends BlockEntity {
         if (tag.hasUUID(NBT_VILLAGE_ID)) {
             villageId = tag.getUUID(NBT_VILLAGE_ID);
         }
+    }
+
+    private void createTownHallZone(ServerLevel level, VillageInfo village) {
+        var chunk = level.getChunk(village.getVillageStartingChunk().x, village.getVillageStartingChunk().z);
+        var villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            return;
+        }
+
+        var zones = villageCapability.getZones();
+        zones.removeIf(zone -> zone.getType() == org.sosly.villageworks.api.data.ZoneType.TOWNHALL);
+        
+        var townHallZone = ZoneFactory.createBlockPosZone(
+            org.sosly.villageworks.api.data.ZoneType.TOWNHALL,
+            getNextZoneId(villageCapability),
+            "Town Hall",
+            worldPosition,
+            level
+        );
+        
+        villageCapability.addZone(townHallZone);
+        VillageWorks.LOGGER.info("Created TOWNHALL zone at {} for village {}", worldPosition, village.getVillageName());
+    }
+
+    private int getNextZoneId(IVillageCapability villageCapability) {
+        return villageCapability.getZones().size() + 1;
     }
 }

--- a/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villageworks/capability/villages/VillagesCapability.java
@@ -126,6 +126,21 @@ public class VillagesCapability implements IVillagesCapability {
         return villages.get(villageId);
     }
 
+    @Override
+    public boolean updateTownHallPos(UUID villageId, BlockPos newPos) {
+        if (villageId == null) {
+            return false;
+        }
+
+        VillageInfo village = villages.get(villageId);
+        if (village == null) {
+            return false;
+        }
+
+        village.setTownHallPos(newPos);
+        return true;
+    }
+
     public void setOwnerLevel(Level level) {
         this.ownerLevel = new WeakReference<>(level);
     }

--- a/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/ZoneCommand.java
@@ -137,6 +137,11 @@ public class ZoneCommand {
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
 
+            if (zoneType == ZoneType.TOWNHALL) {
+                source.sendFailure(Component.literal("TOWNHALL zones are automatically managed and cannot be created manually"));
+                return 0;
+            }
+
             BlockPos pos1 = BlockPosArgument.getBlockPos(context, "pos1");
             BlockPos pos2 = BlockPosArgument.getBlockPos(context, "pos2");
 
@@ -171,6 +176,11 @@ public class ZoneCommand {
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
 
+            if (zoneType == ZoneType.TOWNHALL) {
+                source.sendFailure(Component.literal("TOWNHALL zones are automatically managed and cannot be created manually"));
+                return 0;
+            }
+
             BlockPos center = BlockPosArgument.getBlockPos(context, "center");
             int radius = IntegerArgumentType.getInteger(context, "radius");
 
@@ -200,6 +210,11 @@ public class ZoneCommand {
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
 
+            if (zoneType == ZoneType.TOWNHALL) {
+                source.sendFailure(Component.literal("TOWNHALL zones are automatically managed and cannot be created manually"));
+                return 0;
+            }
+
             BlockPos pos = BlockPosArgument.getBlockPos(context, "pos");
 
             return createZoneInVillage(source, villageId, level -> {
@@ -227,6 +242,11 @@ public class ZoneCommand {
             CommandSourceStack source = context.getSource();
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ZoneType zoneType = ZoneTypeArgument.getZoneType(context, "type");
+
+            if (zoneType == ZoneType.TOWNHALL) {
+                source.sendFailure(Component.literal("TOWNHALL zones are automatically managed and cannot be created manually"));
+                return 0;
+            }
 
             return createZoneInVillage(source, villageId, level -> {
                 int nextId = getNextZoneId(level, villageId);

--- a/src/main/java/org/sosly/villageworks/data/VillageInfo.java
+++ b/src/main/java/org/sosly/villageworks/data/VillageInfo.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public class VillageInfo {
     
     private final UUID villageId;
-    private final BlockPos townHallPos;
+    private BlockPos townHallPos;
     private final ChunkPos villageStartingChunk;
     private final int squadius;
     private final String villageName;
@@ -30,6 +30,10 @@ public class VillageInfo {
         return townHallPos;
     }
     
+    public void setTownHallPos(BlockPos townHallPos) {
+        this.townHallPos = townHallPos;
+    }
+    
     public ChunkPos getVillageStartingChunk() {
         return villageStartingChunk;
     }
@@ -48,7 +52,7 @@ public class VillageInfo {
             return false;
         }
         
-        ChunkPos centerChunk = new ChunkPos(townHallPos);
+        ChunkPos centerChunk = townHallPos != null ? new ChunkPos(townHallPos) : villageStartingChunk;
         int centerX = centerChunk.x;
         int centerZ = centerChunk.z;
         
@@ -67,8 +71,8 @@ public class VillageInfo {
             return false;
         }
         
-        ChunkPos thisChunk = new ChunkPos(townHallPos);
-        ChunkPos otherChunk = new ChunkPos(other.townHallPos);
+        ChunkPos thisChunk = townHallPos != null ? new ChunkPos(townHallPos) : villageStartingChunk;
+        ChunkPos otherChunk = other.townHallPos != null ? new ChunkPos(other.townHallPos) : other.villageStartingChunk;
         
         int thisMinX = thisChunk.x - squadius - minDistance;
         int thisMaxX = thisChunk.x + squadius + minDistance;
@@ -87,7 +91,9 @@ public class VillageInfo {
     public CompoundTag serializeNBT() {
         CompoundTag tag = new CompoundTag();
         tag.putString("VillageId", villageId.toString());
-        tag.putLong("TownHallPos", townHallPos.asLong());
+        if (townHallPos != null) {
+            tag.putLong("TownHallPos", townHallPos.asLong());
+        }
         tag.putLong("VillageStartingChunk", villageStartingChunk.toLong());
         tag.putString("VillageName", villageName);
         tag.putInt("Squadius", squadius);
@@ -95,7 +101,7 @@ public class VillageInfo {
     }
     
     public static VillageInfo deserializeNBT(CompoundTag tag) {
-        if (!tag.contains("VillageId") || !tag.contains("TownHallPos") ||
+        if (!tag.contains("VillageId") ||
             !tag.contains("VillageStartingChunk") || !tag.contains("VillageName") || 
             !tag.contains("Squadius")) {
             return null;
@@ -103,7 +109,7 @@ public class VillageInfo {
         
         try {
             UUID villageId = UUID.fromString(tag.getString("VillageId"));
-            BlockPos townHallPos = BlockPos.of(tag.getLong("TownHallPos"));
+            BlockPos townHallPos = tag.contains("TownHallPos") ? BlockPos.of(tag.getLong("TownHallPos")) : null;
             ChunkPos villageStartingChunk = new ChunkPos(tag.getLong("VillageStartingChunk"));
             String villageName = tag.getString("VillageName");
             int squadius = tag.getInt("Squadius");

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
@@ -26,6 +26,7 @@ public class EatFood extends Behavior<Villager> {
 
     @Override
     protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        
         Boolean canEat = villager.getBrain().getMemory(MemoryModuleTypes.CAN_EAT.get()).orElse(false);
         if (!canEat) {
             return false;


### PR DESCRIPTION
# Town Hall Zone Auto-Management
Automatically create and destroy Town Hall zones when the Town Hall block is placed or removed, ensuring the zone always exists at the block's location.

## Changes
- Made VillageInfo.townHallPos mutable to support town hall movement
- Added updateTownHallPos method to IVillagesCapability and implementation
- Fixed TownHallBlock.onRemove to get BlockEntity before super call
- Clear town hall position and remove TOWNHALL zone when block destroyed
- Allow town hall placement in existing villages that don't have town halls
- Automatically create TOWNHALL zone when block placed
- Prevent manual creation of TOWNHALL zones via zone commands
- Use villageStartingChunk as fallback when townHallPos is null for village discovery

## Related Issues
Resolves #36

## Implementation Notes
Fixed critical bug where onRemove was broken due to accessing BlockEntity after super call. Villages now persist when town halls are removed, allowing replacement. Zone creation uses BlockPos zone type with "Town Hall" name.

## Breaking Changes
None