### PR TITLE
feat: implement profession system for villagers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/vw hunger` - Check villager hunger status
 - `/vw exhaust` - Add exhaustion to villagers (for testing)
 - `/vw village create/remove/list/info` - Manage villages
+- `/vw villager <targets> profession [<profession>]` - View or set villager professions
 - `/vw zone create/delete/rename/info/list` - Manage village zones
 - `/vw zone path add/clear` - Build custom path-shaped zones

--- a/src/main/java/org/sosly/villageworks/VillageWorks.java
+++ b/src/main/java/org/sosly/villageworks/VillageWorks.java
@@ -17,6 +17,8 @@ import org.sosly.villageworks.entity.EntityTypes;
 import org.sosly.villageworks.entity.MemoryModuleTypes;
 import org.sosly.villageworks.entity.Villager;
 import org.sosly.villageworks.entity.ai.SensorTypes;
+import org.sosly.villageworks.event.RegisterProfessionsEvent;
+import org.sosly.villageworks.profession.ProfessionRegistry;
 
 @Mod(VillageWorks.MOD_ID)
 public class VillageWorks {
@@ -41,6 +43,10 @@ public class VillageWorks {
     }
 
     private void setup(final FMLCommonSetupEvent event) {
+        LOGGER.info("Registering extended professions");
+        event.enqueueWork(() -> {
+            MinecraftForge.EVENT_BUS.post(new RegisterProfessionsEvent(ProfessionRegistry.INSTANCE));
+        });
         LOGGER.info("VillageWorks setup complete");
     }
 

--- a/src/main/java/org/sosly/villageworks/api/IProfession.java
+++ b/src/main/java/org/sosly/villageworks/api/IProfession.java
@@ -1,4 +1,4 @@
-package org.sosly.villageworks.api.profession;
+package org.sosly.villageworks.api;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;

--- a/src/main/java/org/sosly/villageworks/api/data/IWantedItem.java
+++ b/src/main/java/org/sosly/villageworks/api/data/IWantedItem.java
@@ -1,0 +1,23 @@
+package org.sosly.villageworks.api.data;
+
+import java.util.function.Predicate;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Represents an immutable specification for items a villager wants to acquire.
+ * Defines both the matching criteria and desired quantity.
+ */
+public interface IWantedItem {
+    /**
+     * Gets the desired quantity of this item.
+     * @return The amount wanted
+     */
+    public int getAmount();
+
+    /**
+     * Gets the predicate used to match desired items.
+     * @return The item matching predicate
+     */
+    public Predicate<ItemStack> getMatcher();
+
+}

--- a/src/main/java/org/sosly/villageworks/api/profession/IProfession.java
+++ b/src/main/java/org/sosly/villageworks/api/profession/IProfession.java
@@ -1,0 +1,75 @@
+package org.sosly.villageworks.api.profession;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.datafixers.util.Pair;
+import java.util.Optional;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.IWantedItem;
+import org.sosly.villageworks.entity.Villager;
+
+/**
+ * Defines a villager profession with its tools, preferences, and work zone requirements.
+ */
+public interface IProfession {
+    /**
+     * Gets the unique identifier for this profession.
+     * @return The profession's resource location ID
+     */
+    public ResourceLocation getID();
+
+    /**
+     * Gets the items this profession always wants to keep in inventory.
+     * @return Optional containing the wanted items specification, or empty if no specific items required
+     */
+    public Optional<IWantedItem> getAlwaysWantedItems();
+
+    /**
+     * Gets the tool requirement for this profession.
+     * @return Optional containing the wanted tool specification, or empty if no tools required
+     */
+    public Optional<IWantedItem> getTool();
+
+    /**
+     * Gets the translation key for displaying this profession's name.
+     * @return The translation key string
+     */
+    public String getTranslationKey();
+
+    /**
+     * Checks if a zone is valid for this profession to work in.
+     * @param zone The zone to validate
+     * @return True if this profession can work in the zone
+     */
+    public boolean isValidWorkZone(IVillageZone zone);
+
+    /**
+     * Gets the memory modules this profession requires.
+     * @return List of memory modules to add to the villager's brain
+     */
+    public ImmutableList<MemoryModuleType<?>> getMemoryModules();
+
+    /**
+     * Gets the sensors this profession requires.
+     * @return List of sensors to add to the villager's brain
+     */
+    public ImmutableList<SensorType<? extends Sensor<? super Villager>>> getSensors();
+
+    /**
+     * Gets the work activity behaviors for this profession.
+     * @param speedModifier The speed modifier for movement behaviors
+     * @return List of prioritized behaviors for the WORK activity
+     */
+    public ImmutableList<? extends Pair<Integer, ? extends BehaviorControl<? super Villager>>> getWorkPackage(float speedModifier);
+
+    /**
+     * Registers profession-specific behaviors to the villager's brain.
+     * @param brain The villager's brain to add behaviors to
+     */
+    public void registerAdditionalGoals(Brain<Villager> brain);
+}

--- a/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
@@ -2,26 +2,34 @@ package org.sosly.villageworks.command;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
-import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.network.chat.Component;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.LevelChunk;
-import org.sosly.villageworks.api.capability.IVillagesCapability;
-import org.sosly.villageworks.capability.Capabilities;
-import org.sosly.villageworks.capability.village.VillageCapability;
-import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
-import org.sosly.villageworks.data.VillageInfo;
-import org.sosly.villageworks.entity.Villager;
-
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import org.sosly.villageworks.api.capability.IVillagesCapability;
+import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
+import org.sosly.villageworks.data.VillageInfo;
+import org.sosly.villageworks.entity.Villager;
+import org.sosly.villageworks.profession.ProfessionRegistry;
 
 public class VillagerCommand {
+    private static final SuggestionProvider<CommandSourceStack> PROFESSION_SUGGESTIONS =
+        (context, builder) -> SharedSuggestionProvider.suggestResource(
+            ProfessionRegistry.INSTANCE.getProfessionIDs().stream(),
+            builder
+        );
+
     public static void register(LiteralArgumentBuilder<CommandSourceStack> parentCommand) {
         parentCommand.then(Commands.literal("villager")
             .then(Commands.argument("targets", EntityArgument.entities())
@@ -29,7 +37,12 @@ public class VillagerCommand {
                     .executes(VillagerCommand::queryVillageAssignment)
                     .then(Commands.argument("villageUUID", VillageUUIDArgument.villageUUID())
                         .suggests((context, builder) -> VillageUUIDArgument.suggest(context, builder))
-                        .executes(VillagerCommand::assignVillage)))));
+                        .executes(VillagerCommand::assignVillage)))
+                .then(Commands.literal("profession")
+                    .executes(VillagerCommand::queryProfession)
+                    .then(Commands.argument("profession", ResourceLocationArgument.id())
+                        .suggests(PROFESSION_SUGGESTIONS)
+                        .executes(VillagerCommand::setProfession)))));
     }
 
     private static int queryVillageAssignment(CommandContext<CommandSourceStack> context) {
@@ -40,7 +53,7 @@ public class VillagerCommand {
             for (Entity entity : entities) {
                 if (entity instanceof Villager villager) {
                     Optional<UUID> villageId = villager.getVillage();
-                    
+
                     if (villageId.isPresent()) {
                         context.getSource().sendSuccess(() ->
                             Component.literal(String.format("Villager %s is assigned to village %s",
@@ -51,7 +64,7 @@ public class VillagerCommand {
                             Component.literal(String.format("Villager %s is not assigned to any village",
                                 villager.getDisplayName().getString())), false);
                     }
-                    
+
                     checkedCount++;
                 }
             }
@@ -74,7 +87,7 @@ public class VillagerCommand {
             Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
             UUID villageId = VillageUUIDArgument.getVillageUUID(context, "villageUUID");
             ServerLevel level = context.getSource().getLevel();
-            
+
             IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
             if (villages == null) {
                 context.getSource().sendFailure(Component.literal("Villages capability not found"));
@@ -110,6 +123,77 @@ public class VillagerCommand {
 
         } catch (Exception e) {
             context.getSource().sendFailure(Component.literal("Failed to assign village: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int queryProfession(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            int checkedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    IProfession profession = villager.getProfession();
+
+                    context.getSource().sendSuccess(() ->
+                        Component.literal(String.format("Villager %s has profession: %s",
+                            villager.getDisplayName().getString(),
+                            profession.getID())), false);
+
+                    checkedCount++;
+                }
+            }
+
+            if (checkedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            return checkedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to query profession: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static int setProfession(CommandContext<CommandSourceStack> context) {
+        try {
+            Collection<? extends Entity> entities = EntityArgument.getEntities(context, "targets");
+            ResourceLocation professionId = ResourceLocationArgument.getId(context, "profession");
+
+            Optional<IProfession> professionOpt = ProfessionRegistry.INSTANCE.getProfession(professionId);
+            if (professionOpt.isEmpty()) {
+                context.getSource().sendFailure(Component.literal("Unknown profession: " + professionId));
+                return 0;
+            }
+
+            IProfession profession = professionOpt.get();
+            int changedCount = 0;
+
+            for (Entity entity : entities) {
+                if (entity instanceof Villager villager) {
+                    villager.setProfession(profession.getID());
+                    changedCount++;
+                }
+            }
+
+            if (changedCount == 0) {
+                context.getSource().sendFailure(Component.literal("No villagers found in selection"));
+                return 0;
+            }
+
+            final int finalChangedCount = changedCount;
+            final ResourceLocation finalProfessionId = professionId;
+            context.getSource().sendSuccess(() ->
+                Component.literal(String.format("Set profession of %d villager(s) to %s",
+                    finalChangedCount, finalProfessionId)), true);
+
+            return changedCount;
+
+        } catch (Exception e) {
+            context.getSource().sendFailure(Component.literal("Failed to set profession: " + e.getMessage()));
             return 0;
         }
     }

--- a/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
+++ b/src/main/java/org/sosly/villageworks/command/VillagerCommand.java
@@ -16,7 +16,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import org.sosly.villageworks.api.capability.IVillagesCapability;
-import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.api.IProfession;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.command.arguments.VillageUUIDArgument;
 import org.sosly.villageworks.data.VillageInfo;

--- a/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villageworks/entity/MemoryModuleTypes.java
@@ -1,16 +1,16 @@
 package org.sosly.villageworks.entity;
 
 import com.mojang.serialization.Codec;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.UUID;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villageworks.VillageWorks;
-
-import java.nio.ByteBuffer;
-import java.util.Optional;
-import java.util.UUID;
 
 public class MemoryModuleTypes {
     public static final DeferredRegister<MemoryModuleType<?>> MEMORY_MODULE_TYPES =
@@ -24,6 +24,9 @@ public class MemoryModuleTypes {
 
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_STARVING =
         MEMORY_MODULE_TYPES.register("is_starving", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+
+    public static final RegistryObject<MemoryModuleType<ResourceLocation>> PROFESSION =
+        MEMORY_MODULE_TYPES.register("profession", () -> new MemoryModuleType<>(Optional.of(ResourceLocation.CODEC)));
 
     public static final RegistryObject<MemoryModuleType<UUID>> VILLAGE =
         MEMORY_MODULE_TYPES.register("village", () -> new MemoryModuleType<>(Optional.of(

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -1,84 +1,67 @@
 package org.sosly.villageworks.entity;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.mojang.serialization.Dynamic;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.food.FoodProperties;
-import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.memory.ExpirableValue;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
 import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.schedule.Schedule;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
+import net.minecraft.world.level.chunk.LevelChunk;
 import org.jetbrains.annotations.NotNull;
 import org.sosly.villageworks.VillageWorks;
-import org.sosly.villageworks.data.LivingEntityFoodData;
-import org.sosly.villageworks.entity.ai.goals.VillagerGoalPackages;
-import org.sosly.villageworks.entity.ai.SensorTypes;
+import org.sosly.villageworks.api.profession.IProfession;
 import org.sosly.villageworks.capability.Capabilities;
+import org.sosly.villageworks.data.LivingEntityFoodData;
 import org.sosly.villageworks.data.VillageInfo;
-
-import javax.annotation.Nullable;
-import java.util.Optional;
-import java.util.UUID;
+import org.sosly.villageworks.entity.ai.SensorTypes;
+import org.sosly.villageworks.entity.ai.goals.VillagerGoalPackages;
+import org.sosly.villageworks.profession.Commoner;
+import org.sosly.villageworks.profession.ProfessionRegistry;
 
 public class Villager extends PathfinderMob {
     private final LivingEntityFoodData foodData;
     private final SimpleContainer inventory;
+    private Dynamic<?> dynamic;
+    private static ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = DefaultVillagerBrain.MEMORY_TYPES;
 
-    private static final ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = ImmutableList.of(
-        MemoryModuleType.HOME,
-        MemoryModuleType.NEAREST_LIVING_ENTITIES,
-        MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,
-        MemoryModuleType.NEAREST_PLAYERS,
-        MemoryModuleType.NEAREST_VISIBLE_PLAYER,
-        MemoryModuleType.WALK_TARGET,
-        MemoryModuleType.LOOK_TARGET,
-        MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE,
-        MemoryModuleType.PATH,
-        MemoryModuleType.HURT_BY,
-        MemoryModuleType.HURT_BY_ENTITY,
-        MemoryModuleType.NEAREST_HOSTILE,
-        MemoryModuleType.LAST_SLEPT,
-        MemoryModuleType.LAST_WOKEN,
-        MemoryModuleTypes.CAN_EAT.get(),
-        MemoryModuleTypes.IS_HUNGRY.get(),
-        MemoryModuleTypes.IS_STARVING.get(),
-        MemoryModuleTypes.VILLAGE.get()
-    );
-
-    private static final ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = ImmutableList.of(
-        SensorType.NEAREST_LIVING_ENTITIES,
-        SensorType.NEAREST_PLAYERS,
-        SensorType.HURT_BY,
-        SensorType.VILLAGER_HOSTILES,
-        SensorTypes.HUNGER.get()
-    );
+    private static ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = DefaultVillagerBrain.SENSOR_TYPES;
 
     public Villager(EntityType<? extends Villager> entityType, Level level) {
         super(entityType, level);
@@ -103,8 +86,8 @@ public class Villager extends PathfinderMob {
 
     @Override
     protected @NotNull Brain<?> makeBrain(@NotNull Dynamic<?> dynamic) {
+        this.dynamic = dynamic;
         Brain<Villager> brain = this.brainProvider().makeBrain(dynamic);
-        this.registerBrainGoals(brain);
         return brain;
     }
 
@@ -113,10 +96,32 @@ public class Villager extends PathfinderMob {
         return (Brain<Villager>) super.getBrain();
     }
 
+    public void rebuildBrainWithProfession() {
+        Map<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> savedMemories =
+                new HashMap<>(this.brain.getMemories());
+
+        MEMORY_TYPES = ImmutableList.<MemoryModuleType<?>>builder()
+            .addAll(DefaultVillagerBrain.MEMORY_TYPES)
+            .addAll(this.getProfession().getMemoryModules())
+            .build();
+        SENSOR_TYPES = ImmutableList.<SensorType<? extends Sensor<? super Villager>>>builder()
+            .addAll(DefaultVillagerBrain.SENSOR_TYPES)
+            .addAll(this.getProfession().getSensors())
+            .build();
+
+        NbtOps nbtops = NbtOps.INSTANCE;
+        this.brain = this.makeBrain(new Dynamic<>(nbtops, nbtops.createMap(ImmutableMap.of(nbtops.createString("memories"), nbtops.emptyMap()))));
+
+        for(Map.Entry<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> entry : savedMemories.entrySet()) {
+            if (entry.getValue().isPresent() && this.brain.getMemories().containsKey(entry.getKey())) {
+                this.brain.getMemories().put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
     public void refreshBrain(ServerLevel serverLevel) {
-        Brain<Villager> brain = this.getBrain();
-        brain.stopAll(serverLevel, this);
-        this.brain = brain.copyWithoutBehaviors();
+        this.getBrain().stopAll(serverLevel, this);
+        this.rebuildBrainWithProfession();
         this.registerBrainGoals(this.getBrain());
     }
 
@@ -127,6 +132,7 @@ public class Villager extends PathfinderMob {
         brain.addActivity(Activity.IDLE, VillagerGoalPackages.getIdlePackage(0.3F));
         brain.addActivity(Activity.REST, VillagerGoalPackages.getRestPackage(0.6F));
         brain.addActivity(Activity.PANIC, VillagerGoalPackages.getPanicPackage(0.6F));
+        brain.addActivity(Activity.WORK, this.getProfession().getWorkPackage(0.6F));
 
         brain.setCoreActivities(ImmutableSet.of(Activity.CORE));
         brain.setDefaultActivity(Activity.IDLE);
@@ -158,6 +164,11 @@ public class Villager extends PathfinderMob {
         if (villageId.isPresent()) {
             tag.putString("VillageId", villageId.get().toString());
         }
+
+        Optional<ResourceLocation> profession = this.brain.getMemory(MemoryModuleTypes.PROFESSION.get());
+        if (profession.isPresent()) {
+            tag.putString("Profession", profession.get().toString());
+        }
     }
 
     @Override
@@ -174,6 +185,12 @@ public class Villager extends PathfinderMob {
             UUID villageId = UUID.fromString(tag.getString("VillageId"));
             this.brain.setMemory(MemoryModuleTypes.VILLAGE.get(), villageId);
         }
+
+        ResourceLocation profession = Commoner.ID;
+        if (tag.contains("Profession") && ResourceLocation.tryParse(tag.getString("Profession")) != null) {
+            profession = ResourceLocation.tryParse(tag.getString("Profession"));
+        }
+        this.brain.setMemory(MemoryModuleTypes.PROFESSION.get(), profession);
 
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());
@@ -238,6 +255,25 @@ public class Villager extends PathfinderMob {
         return this.brain.getMemory(MemoryModuleType.HOME)
             .map(GlobalPos::pos)
             .orElse(null);
+    }
+
+    public IProfession getProfession() {
+        ResourceLocation professionId = this.brain.getMemory(MemoryModuleTypes.PROFESSION.get()).orElse(Commoner.ID);
+        return ProfessionRegistry.INSTANCE.getProfession(professionId).orElse(new Commoner());
+    }
+
+    public void setProfession(ResourceLocation professionId) {
+        IProfession profession = ProfessionRegistry.INSTANCE.getProfession(professionId).orElse(null);
+        if (profession == null) {
+            return;
+        }
+
+        this.brain.setMemory(MemoryModuleTypes.PROFESSION.get(), professionId);
+
+        if (!(this.level() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        this.refreshBrain(serverLevel);
     }
 
     public Optional<UUID> getVillage() {
@@ -391,5 +427,37 @@ public class Villager extends PathfinderMob {
         }
 
         return bedPos.relative(blockState.getValue(BedBlock.FACING));
+    }
+
+    protected static class DefaultVillagerBrain {
+        protected static ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = ImmutableList.of(
+            MemoryModuleType.HOME,
+            MemoryModuleType.NEAREST_LIVING_ENTITIES,
+            MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,
+            MemoryModuleType.NEAREST_PLAYERS,
+            MemoryModuleType.NEAREST_VISIBLE_PLAYER,
+            MemoryModuleType.WALK_TARGET,
+            MemoryModuleType.LOOK_TARGET,
+            MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE,
+            MemoryModuleType.PATH,
+            MemoryModuleType.HURT_BY,
+            MemoryModuleType.HURT_BY_ENTITY,
+            MemoryModuleType.NEAREST_HOSTILE,
+            MemoryModuleType.LAST_SLEPT,
+            MemoryModuleType.LAST_WOKEN,
+            MemoryModuleTypes.CAN_EAT.get(),
+            MemoryModuleTypes.IS_HUNGRY.get(),
+            MemoryModuleTypes.IS_STARVING.get(),
+            MemoryModuleTypes.PROFESSION.get(),
+            MemoryModuleTypes.VILLAGE.get()
+        );
+
+        protected static final ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = ImmutableList.of(
+                SensorType.NEAREST_LIVING_ENTITIES,
+                SensorType.NEAREST_PLAYERS,
+                SensorType.HURT_BY,
+                SensorType.VILLAGER_HOSTILES,
+                SensorTypes.HUNGER.get()
+        );
     }
 }

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -46,7 +46,7 @@ import net.minecraft.world.level.block.state.properties.BedPart;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.jetbrains.annotations.NotNull;
 import org.sosly.villageworks.VillageWorks;
-import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.api.IProfession;
 import org.sosly.villageworks.capability.Capabilities;
 import org.sosly.villageworks.data.LivingEntityFoodData;
 import org.sosly.villageworks.data.VillageInfo;
@@ -59,9 +59,9 @@ public class Villager extends PathfinderMob {
     private final LivingEntityFoodData foodData;
     private final SimpleContainer inventory;
     private Dynamic<?> dynamic;
-    private static ImmutableList<MemoryModuleType<?>> MEMORY_TYPES = DefaultVillagerBrain.MEMORY_TYPES;
+    private ImmutableList<MemoryModuleType<?>> memoryTypes = DefaultVillagerBrain.MEMORY_TYPES;
 
-    private static ImmutableList<SensorType<? extends Sensor<? super Villager>>> SENSOR_TYPES = DefaultVillagerBrain.SENSOR_TYPES;
+    private ImmutableList<SensorType<? extends Sensor<? super Villager>>> sensorTypes = DefaultVillagerBrain.SENSOR_TYPES;
 
     public Villager(EntityType<? extends Villager> entityType, Level level) {
         super(entityType, level);
@@ -81,7 +81,7 @@ public class Villager extends PathfinderMob {
 
     @Override
     protected Brain.@NotNull Provider<Villager> brainProvider() {
-        return Brain.provider(MEMORY_TYPES, SENSOR_TYPES);
+        return Brain.provider(this.memoryTypes, this.sensorTypes);
     }
 
     @Override
@@ -100,11 +100,11 @@ public class Villager extends PathfinderMob {
         Map<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> savedMemories =
                 new HashMap<>(this.brain.getMemories());
 
-        MEMORY_TYPES = ImmutableList.<MemoryModuleType<?>>builder()
+        this.memoryTypes = ImmutableList.<MemoryModuleType<?>>builder()
             .addAll(DefaultVillagerBrain.MEMORY_TYPES)
             .addAll(this.getProfession().getMemoryModules())
             .build();
-        SENSOR_TYPES = ImmutableList.<SensorType<? extends Sensor<? super Villager>>>builder()
+        this.sensorTypes = ImmutableList.<SensorType<? extends Sensor<? super Villager>>>builder()
             .addAll(DefaultVillagerBrain.SENSOR_TYPES)
             .addAll(this.getProfession().getSensors())
             .build();

--- a/src/main/java/org/sosly/villageworks/event/RegisterProfessionsEvent.java
+++ b/src/main/java/org/sosly/villageworks/event/RegisterProfessionsEvent.java
@@ -1,0 +1,17 @@
+package org.sosly.villageworks.event;
+
+import net.minecraftforge.eventbus.api.Event;
+import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.profession.ProfessionRegistry;
+
+public class RegisterProfessionsEvent extends Event {
+    private final ProfessionRegistry registry;
+
+    public RegisterProfessionsEvent(ProfessionRegistry professions) {
+        this.registry = professions;
+    }
+
+    public void register(IProfession profession) {
+        registry.register(profession);
+    }
+}

--- a/src/main/java/org/sosly/villageworks/event/RegisterProfessionsEvent.java
+++ b/src/main/java/org/sosly/villageworks/event/RegisterProfessionsEvent.java
@@ -1,7 +1,7 @@
 package org.sosly.villageworks.event;
 
 import net.minecraftforge.eventbus.api.Event;
-import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.api.IProfession;
 import org.sosly.villageworks.profession.ProfessionRegistry;
 
 public class RegisterProfessionsEvent extends Event {

--- a/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
+++ b/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
@@ -1,0 +1,22 @@
+package org.sosly.villageworks.profession;
+
+import net.minecraft.resources.ResourceLocation;
+import org.sosly.villageworks.api.profession.IProfession;
+
+public abstract class AbstractProfession implements IProfession {
+    private final ResourceLocation id;
+
+    protected AbstractProfession(ResourceLocation id) {
+        this.id = id;
+    }
+
+    @Override
+    public ResourceLocation getID() {
+        return id;
+    }
+
+    @Override
+    public String getTranslationKey() {
+        return "profession." + getID().toString().replace(":", ".");
+    }
+}

--- a/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
+++ b/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
@@ -1,7 +1,7 @@
 package org.sosly.villageworks.profession;
 
 import net.minecraft.resources.ResourceLocation;
-import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.api.IProfession;
 
 public abstract class AbstractProfession implements IProfession {
     private final ResourceLocation id;

--- a/src/main/java/org/sosly/villageworks/profession/Commoner.java
+++ b/src/main/java/org/sosly/villageworks/profession/Commoner.java
@@ -1,0 +1,56 @@
+package org.sosly.villageworks.profession;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.datafixers.util.Pair;
+import java.util.Optional;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.api.data.IVillageZone;
+import org.sosly.villageworks.api.data.IWantedItem;
+import org.sosly.villageworks.entity.Villager;
+
+public class Commoner extends AbstractProfession {
+    public final static ResourceLocation ID = new ResourceLocation(VillageWorks.MOD_ID, "commoner");
+    public Commoner() {
+        super(ID);
+    }
+
+    @Override
+    public Optional<IWantedItem> getAlwaysWantedItems() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<IWantedItem> getTool() {
+        return Optional.empty();
+    }
+
+    @Override
+    public ImmutableList<MemoryModuleType<?>> getMemoryModules() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public ImmutableList<SensorType<? extends Sensor<? super Villager>>> getSensors() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public ImmutableList<? extends Pair<Integer, ? extends BehaviorControl<? super Villager>>> getWorkPackage(float speedModifier) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public void registerAdditionalGoals(Brain<Villager> brain) {
+    }
+
+    @Override
+    public boolean isValidWorkZone(IVillageZone zone) {
+        return false;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/profession/ProfessionRegistry.java
+++ b/src/main/java/org/sosly/villageworks/profession/ProfessionRegistry.java
@@ -1,0 +1,36 @@
+package org.sosly.villageworks.profession;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import net.minecraft.resources.ResourceLocation;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.api.profession.IProfession;
+
+public class ProfessionRegistry {
+    public static final ProfessionRegistry INSTANCE = new ProfessionRegistry();
+    private final Map<ResourceLocation, IProfession> professions = new HashMap<ResourceLocation, IProfession>();
+    private ProfessionRegistry() {}
+
+    public void register(IProfession profession) {
+        ResourceLocation id = profession.getID();
+        if (professions.containsKey(id)) {
+            VillageWorks.LOGGER.warn("Attempted to register profession " + profession.getID() + " twice");
+        }
+        professions.put(id, profession);
+    }
+
+    public Optional<IProfession> getProfession(ResourceLocation id) {
+        return Optional.ofNullable(professions.get(id));
+    }
+
+    public Collection<IProfession> getProfessions() {
+        return professions.values();
+    }
+
+    public Set<ResourceLocation> getProfessionIDs() {
+        return professions.keySet();
+    }
+}

--- a/src/main/java/org/sosly/villageworks/profession/ProfessionRegistry.java
+++ b/src/main/java/org/sosly/villageworks/profession/ProfessionRegistry.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import net.minecraft.resources.ResourceLocation;
 import org.sosly.villageworks.VillageWorks;
-import org.sosly.villageworks.api.profession.IProfession;
+import org.sosly.villageworks.api.IProfession;
 
 public class ProfessionRegistry {
     public static final ProfessionRegistry INSTANCE = new ProfessionRegistry();
@@ -18,6 +18,7 @@ public class ProfessionRegistry {
         ResourceLocation id = profession.getID();
         if (professions.containsKey(id)) {
             VillageWorks.LOGGER.warn("Attempted to register profession " + profession.getID() + " twice");
+            return;
         }
         professions.put(id, profession);
     }

--- a/src/main/java/org/sosly/villageworks/profession/Professions.java
+++ b/src/main/java/org/sosly/villageworks/profession/Professions.java
@@ -5,7 +5,7 @@ import net.minecraftforge.fml.common.Mod;
 import org.sosly.villageworks.VillageWorks;
 import org.sosly.villageworks.event.RegisterProfessionsEvent;
 
-@Mod.EventBusSubscriber(modid= VillageWorks.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid = VillageWorks.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 
 public class Professions {
     @SubscribeEvent

--- a/src/main/java/org/sosly/villageworks/profession/Professions.java
+++ b/src/main/java/org/sosly/villageworks/profession/Professions.java
@@ -1,0 +1,15 @@
+package org.sosly.villageworks.profession;
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.sosly.villageworks.VillageWorks;
+import org.sosly.villageworks.event.RegisterProfessionsEvent;
+
+@Mod.EventBusSubscriber(modid= VillageWorks.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+
+public class Professions {
+    @SubscribeEvent
+    public static void onRegisterProfessions(RegisterProfessionsEvent event) {
+        event.register(new Commoner());
+    }
+}


### PR DESCRIPTION
# Implement Profession System for Villagers
Creates a data-driven profession system that defines villager job types and their unique behaviors.

## Changes
- Added `IProfession` interface to define profession capabilities
- Created `ProfessionRegistry` for managing available professions
- Implemented `Commoner` as the default unemployed profession
- Added `PROFESSION` memory module to track villager jobs
- Enhanced `Villager` entity to dynamically rebuild brains with profession-specific modules
- Added `/vw villager profession` command for viewing/setting professions
- Created `IWantedItem` interface for defining profession tool/item requirements

## Related Issues
Resolves #38

## Implementation Notes
Villagers initially spawn with a basic brain, then rebuild it with profession-specific memory modules and sensors after loading NBT data. This allows each profession to define its own AI components without requiring all villagers to have all possible modules.

## Breaking Changes
None