### PR TITLE
Add ItemMatcher enum for item identification

### DIFF
--- a/src/main/java/org/sosly/villageworks/api/data/IWantedItem.java
+++ b/src/main/java/org/sosly/villageworks/api/data/IWantedItem.java
@@ -2,12 +2,15 @@ package org.sosly.villageworks.api.data;
 
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
+import org.sosly.villageworks.data.WantedItem;
 
 /**
  * Represents an immutable specification for items a villager wants to acquire.
  * Defines both the matching criteria and desired quantity.
  */
 public interface IWantedItem {
+    public static final IWantedItem EMPTY = new WantedItem(stack -> false, 0);
+
     /**
      * Gets the desired quantity of this item.
      * @return The amount wanted

--- a/src/main/java/org/sosly/villageworks/data/WantedItem.java
+++ b/src/main/java/org/sosly/villageworks/data/WantedItem.java
@@ -1,0 +1,25 @@
+package org.sosly.villageworks.data;
+
+import java.util.function.Predicate;
+import net.minecraft.world.item.ItemStack;
+import org.sosly.villageworks.api.data.IWantedItem;
+
+public class WantedItem implements IWantedItem {
+    private final Predicate<ItemStack> matcher;
+    private final int amount;
+    public WantedItem(Predicate<ItemStack> matcher, int amount) {
+        this.matcher = matcher;
+        this.amount = amount;
+    }
+
+
+    @Override
+    public int getAmount() {
+        return amount;
+    }
+
+    @Override
+    public Predicate<ItemStack> getMatcher() {
+        return matcher;
+    }
+}

--- a/src/main/java/org/sosly/villageworks/helper/ItemMatcher.java
+++ b/src/main/java/org/sosly/villageworks/helper/ItemMatcher.java
@@ -1,0 +1,30 @@
+package org.sosly.villageworks.helper;
+
+import net.minecraft.world.item.ItemStack;
+import org.sosly.villageworks.api.data.IWantedItem;
+import org.sosly.villageworks.data.WantedItem;
+import org.sosly.villageworks.entity.Villager;
+
+public enum ItemMatcher {
+    PROFESSION_TOOL {
+        @Override
+        public IWantedItem getFor(Villager villager) {
+            return villager.getProfession().getTool().orElse(IWantedItem.EMPTY);
+        }
+    },
+    FOOD {
+        @Override
+        public IWantedItem getFor(Villager villager) {
+            return new WantedItem(ItemStack::isEdible, 3);
+        }
+    },
+    RESOURCES {
+        @Override
+        public IWantedItem getFor(Villager villager) {
+            // todo: add items from the current recipe or schematic the villager is working on
+            return villager.getProfession().getAlwaysWantedItems().orElse(IWantedItem.EMPTY);
+        }
+    };
+
+    public abstract IWantedItem getFor(Villager villager);
+}


### PR DESCRIPTION
# Add ItemMatcher enum for item identification
Implements ItemMatcher enum to generate predicates for identifying items based on villager needs.

## Changes
- Created ItemMatcher enum in helper package with three matcher types
- Added PROFESSION_TOOL matcher that uses profession.getTool()
- Added FOOD matcher that identifies any edible items (wants 3)
- Added RESOURCES matcher that uses profession.getAlwaysWantedItems()
- Added IWantedItem.EMPTY constant for safe null handling
- Returns IWantedItem instead of raw predicates to include quantity information

## Related Issues
Resolves #43

## Implementation Notes
ItemMatcher returns IWantedItem instances rather than just predicates, allowing it to specify both the matching criteria and desired quantity. The RESOURCES matcher includes a todo comment for future enhancement when recipe/schematic support is added.

## Breaking Changes
None