### PR TITLE
Add profession-based work schedules

### DIFF
--- a/src/main/java/org/sosly/villageworks/api/IProfession.java
+++ b/src/main/java/org/sosly/villageworks/api/IProfession.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.ai.behavior.BehaviorControl;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.entity.schedule.Schedule;
 import org.sosly.villageworks.api.data.IVillageZone;
 import org.sosly.villageworks.api.data.IWantedItem;
 import org.sosly.villageworks.entity.Villager;
@@ -72,4 +73,10 @@ public interface IProfession {
      * @param brain The villager's brain to add behaviors to
      */
     public void registerAdditionalGoals(Brain<Villager> brain);
+
+    /**
+     * Gets the work schedule for this profession.
+     * @return The schedule defining when this profession works, rests, and socializes
+     */
+    public Schedule getSchedule();
 }

--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -130,7 +130,7 @@ public class Villager extends PathfinderMob {
     }
 
     private void registerBrainGoals(Brain<Villager> brain) {
-        brain.setSchedule(Schedule.VILLAGER_DEFAULT);
+        brain.setSchedule(this.getProfession().getSchedule());
 
         brain.addActivity(Activity.CORE, VillagerGoalPackages.getCorePackage());
         brain.addActivity(Activity.IDLE, VillagerGoalPackages.getIdlePackage(0.3F));

--- a/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
+++ b/src/main/java/org/sosly/villageworks/profession/AbstractProfession.java
@@ -1,6 +1,9 @@
 package org.sosly.villageworks.profession;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.schedule.Activity;
+import net.minecraft.world.entity.schedule.Schedule;
+import net.minecraft.world.entity.schedule.ScheduleBuilder;
 import org.sosly.villageworks.api.IProfession;
 
 public abstract class AbstractProfession implements IProfession {
@@ -18,5 +21,15 @@ public abstract class AbstractProfession implements IProfession {
     @Override
     public String getTranslationKey() {
         return "profession." + getID().toString().replace(":", ".");
+    }
+
+    @Override
+    public Schedule getSchedule() {
+        return new ScheduleBuilder(new Schedule())
+            .changeActivityAt(0, Activity.IDLE)       // IDLE  (6 AM - 8 AM, morning routine)
+            .changeActivityAt(2000, Activity.WORK)    // WORK  (8 AM - 5 PM, 9-hour work day)
+            .changeActivityAt(11000, Activity.IDLE)   // IDLE  (5 PM - 8 PM, evening social)
+            .changeActivityAt(14000, Activity.REST)   // REST  (8 PM - 6 AM, sleep)
+            .build();
     }
 }


### PR DESCRIPTION
# Add profession-based work schedules
Implements work schedules through the profession system, allowing each profession to define its own daily routine.

## Changes
- Added getSchedule() method to IProfession interface
- Implemented default work schedule in AbstractProfession
- Updated Villager to use profession's schedule instead of vanilla VILLAGER_DEFAULT
- Removed need for separate Schedules registry by building schedules dynamically

## Schedule Timeline
Daily schedule (24000 ticks = 1 day):
- 0-2000: IDLE (6-8 AM morning routine)
- 2000-11000: WORK (8 AM-5 PM work day)
- 11000-14000: IDLE (5-8 PM evening social)
- 14000-24000: REST (8 PM-6 AM sleep)

## Related Issues
Resolves #60

## Implementation Notes
Each profession can override getSchedule() to define custom schedules (e.g., night guards, early morning bakers). The default schedule provides a realistic work day with morning/evening social periods.

## Breaking Changes
None