### PR TITLE
Expand villager inventory from 1 to 5 slots

### DIFF
--- a/src/main/java/org/sosly/villageworks/entity/Villager.java
+++ b/src/main/java/org/sosly/villageworks/entity/Villager.java
@@ -12,6 +12,8 @@ import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -65,7 +67,7 @@ public class Villager extends PathfinderMob {
     public Villager(EntityType<? extends Villager> entityType, Level level) {
         super(entityType, level);
         this.foodData = new LivingEntityFoodData();
-        this.inventory = new SimpleContainer(1);
+        this.inventory = new SimpleContainer(5);
         ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
         this.getNavigation().setCanFloat(true);
         this.setCanPickUpLoot(true);
@@ -157,11 +159,18 @@ public class Villager extends PathfinderMob {
     public void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
         this.foodData.addAdditionalSaveData(tag);
-        ItemStack inventoryItem = this.inventory.getItem(0);
-        if (!inventoryItem.isEmpty()) {
-            CompoundTag itemTag = new CompoundTag();
-            inventoryItem.save(itemTag);
-            tag.put("InventoryItem", itemTag);
+        ListTag inventoryListTag = new ListTag();
+        for (int i = 0; i < this.inventory.getContainerSize(); i++) {
+            ItemStack itemStack = this.inventory.getItem(i);
+            if (!itemStack.isEmpty()) {
+                CompoundTag itemTag = new CompoundTag();
+                itemTag.putByte("Slot", (byte) i);
+                itemStack.save(itemTag);
+                inventoryListTag.add(itemTag);
+            }
+        }
+        if (!inventoryListTag.isEmpty()) {
+            tag.put("Inventory", inventoryListTag);
         }
 
         Optional<UUID> villageId = this.brain.getMemory(MemoryModuleTypes.VILLAGE.get());
@@ -179,7 +188,17 @@ public class Villager extends PathfinderMob {
     public void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         this.foodData.readAdditionalSaveData(tag);
-        if (tag.contains("InventoryItem")) {
+        if (tag.contains("Inventory", Tag.TAG_LIST)) {
+            ListTag inventoryListTag = tag.getList("Inventory", Tag.TAG_COMPOUND);
+            for (int i = 0; i < inventoryListTag.size(); i++) {
+                CompoundTag itemTag = inventoryListTag.getCompound(i);
+                byte slot = itemTag.getByte("Slot");
+                if (slot >= 0 && slot < this.inventory.getContainerSize()) {
+                    ItemStack itemStack = ItemStack.of(itemTag);
+                    this.inventory.setItem(slot, itemStack);
+                }
+            }
+        } else if (tag.contains("InventoryItem")) {
             CompoundTag itemTag = tag.getCompound("InventoryItem");
             ItemStack inventoryItem = ItemStack.of(itemTag);
             this.inventory.setItem(0, inventoryItem);
@@ -379,43 +398,17 @@ public class Villager extends PathfinderMob {
         return this.inventory;
     }
 
-    @Override
-    public @NotNull InteractionResult mobInteract(@NotNull Player player, @NotNull InteractionHand hand) {
-        ItemStack itemStack = player.getItemInHand(hand);
-
-        if (itemStack.isEmpty()) {
-            return InteractionResult.PASS;
-        }
-
-        if (!this.inventory.getItem(0).isEmpty()) {
-            return InteractionResult.PASS;
-        }
-
-        FoodProperties foodProperties = itemStack.getFoodProperties(this);
-        if (foodProperties == null || foodProperties.getSaturationModifier() <= 0) {
-            return InteractionResult.PASS;
-        }
-
-        ItemStack singleItem = itemStack.copy();
-        singleItem.setCount(1);
-        this.inventory.setItem(0, singleItem);
-
-        if (!player.getAbilities().instabuild) {
-            itemStack.shrink(1);
-        }
-
-        this.playSound(SoundEvents.ITEM_PICKUP, 1.0F, 1.0F);
-        return InteractionResult.SUCCESS;
-    }
 
     @Override
     protected void dropCustomDeathLoot(@NotNull DamageSource damageSource, int looting, boolean recentlyHit) {
         super.dropCustomDeathLoot(damageSource, looting, recentlyHit);
 
-        ItemStack inventoryItem = this.inventory.getItem(0);
-        if (!inventoryItem.isEmpty()) {
-            ItemEntity itemEntity = new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(), inventoryItem);
-            this.level().addFreshEntity(itemEntity);
+        for (int i = 0; i < this.inventory.getContainerSize(); i++) {
+            ItemStack inventoryItem = this.inventory.getItem(i);
+            if (!inventoryItem.isEmpty()) {
+                ItemEntity itemEntity = new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(), inventoryItem);
+                this.level().addFreshEntity(itemEntity);
+            }
         }
     }
 

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
@@ -93,7 +93,7 @@ public class EatFood extends Behavior<Villager> {
         SimpleContainer inventory = villager.getInventory();
         for (int i = 0; i < inventory.getContainerSize(); i++) {
             ItemStack inventoryItem = inventory.getItem(i);
-            if (!inventoryItem.isEmpty() && inventoryItem.is(this.foodToEat.getItem())) {
+            if (!inventoryItem.isEmpty() && ItemStack.isSameItemSameTags(inventoryItem, this.foodToEat)) {
                 inventoryItem.shrink(1);
                 break;
             }

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/EatFood.java
@@ -8,8 +8,10 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.SimpleContainer;
+import org.sosly.villageworks.api.data.IWantedItem;
 import org.sosly.villageworks.entity.Villager;
 import org.sosly.villageworks.entity.MemoryModuleTypes;
+import org.sosly.villageworks.helper.ItemMatcher;
 
 public class EatFood extends Behavior<Villager> {
     private static final int EATING_DURATION = 32;
@@ -89,9 +91,12 @@ public class EatFood extends Behavior<Villager> {
         villager.getFoodData().eat(foodProperties.getNutrition(), foodProperties.getSaturationModifier());
 
         SimpleContainer inventory = villager.getInventory();
-        ItemStack inventoryItem = inventory.getItem(0);
-        if (!inventoryItem.isEmpty() && inventoryItem.is(this.foodToEat.getItem())) {
-            inventoryItem.shrink(1);
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack inventoryItem = inventory.getItem(i);
+            if (!inventoryItem.isEmpty() && inventoryItem.is(this.foodToEat.getItem())) {
+                inventoryItem.shrink(1);
+                break;
+            }
         }
 
         this.foodToEat = ItemStack.EMPTY;
@@ -100,18 +105,34 @@ public class EatFood extends Behavior<Villager> {
 
     private ItemStack findBestFood(Villager villager) {
         SimpleContainer inventory = villager.getInventory();
-        ItemStack item = inventory.getItem(0);
-
-        if (item.isEmpty()) {
-            return ItemStack.EMPTY;
+        IWantedItem foodMatcher = ItemMatcher.FOOD.getFor(villager);
+        
+        ItemStack bestFood = ItemStack.EMPTY;
+        float bestSaturation = 0.0f;
+        
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack item = inventory.getItem(i);
+            if (item.isEmpty()) {
+                continue;
+            }
+            
+            if (!foodMatcher.getMatcher().test(item)) {
+                continue;
+            }
+            
+            FoodProperties foodProperties = item.getFoodProperties(villager);
+            if (foodProperties == null) {
+                continue;
+            }
+            
+            float saturation = foodProperties.getSaturationModifier();
+            if (saturation > bestSaturation) {
+                bestFood = item;
+                bestSaturation = saturation;
+            }
         }
-
-        FoodProperties foodProperties = item.getFoodProperties(villager);
-        if (foodProperties == null) {
-            return ItemStack.EMPTY;
-        }
-
-        return item;
+        
+        return bestFood;
     }
 
     private void playEatingSound(ServerLevel level, Villager villager) {

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
@@ -109,16 +109,24 @@ public class FindFoodInStorageBehavior extends Behavior<Villager> {
         
         this.searchTicks++;
         
-        if (this.searchTicks >= SEARCH_DURATION) {
-            ItemStack extractedFood = ContainerHelper.extractItemFromContainer(level, this.targetContainer, FindFoodInStorageBehavior::isFood);
-            if (!extractedFood.isEmpty()) {
-                int emptySlot = findFirstEmptySlot(villager);
-                if (emptySlot >= 0) {
-                    villager.getInventory().setItem(emptySlot, extractedFood);
-                }
-            }
-            this.searchingForFood = false;
+        if (this.searchTicks < SEARCH_DURATION) {
+            return;
         }
+        
+        int emptySlot = findFirstEmptySlot(villager);
+        if (emptySlot < 0) {
+            this.searchingForFood = false;
+            return;
+        }
+        
+        ItemStack extractedFood = ContainerHelper.extractItemFromContainer(level, this.targetContainer, FindFoodInStorageBehavior::isFood);
+        if (extractedFood.isEmpty()) {
+            this.searchingForFood = false;
+            return;
+        }
+        
+        villager.getInventory().setItem(emptySlot, extractedFood);
+        this.searchingForFood = false;
     }
 
     @Override

--- a/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
+++ b/src/main/java/org/sosly/villageworks/entity/ai/behavior/FindFoodInStorageBehavior.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.ai.behavior.Behavior;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
@@ -51,7 +52,7 @@ public class FindFoodInStorageBehavior extends Behavior<Villager> {
             return false;
         }
 
-        if (!villager.getInventory().getItem(0).isEmpty()) {
+        if (hasAnyFood(villager)) {
             return false;
         }
 
@@ -85,7 +86,7 @@ public class FindFoodInStorageBehavior extends Behavior<Villager> {
         }
 
         Boolean isHungry = villager.getBrain().getMemory(MemoryModuleTypes.IS_HUNGRY.get()).orElse(false);
-        return isHungry && villager.getInventory().getItem(0).isEmpty();
+        return isHungry && !hasAnyFood(villager);
     }
 
     @Override
@@ -111,7 +112,10 @@ public class FindFoodInStorageBehavior extends Behavior<Villager> {
         if (this.searchTicks >= SEARCH_DURATION) {
             ItemStack extractedFood = ContainerHelper.extractItemFromContainer(level, this.targetContainer, FindFoodInStorageBehavior::isFood);
             if (!extractedFood.isEmpty()) {
-                villager.getInventory().setItem(0, extractedFood);
+                int emptySlot = findFirstEmptySlot(villager);
+                if (emptySlot >= 0) {
+                    villager.getInventory().setItem(emptySlot, extractedFood);
+                }
             }
             this.searchingForFood = false;
         }
@@ -181,5 +185,26 @@ public class FindFoodInStorageBehavior extends Behavior<Villager> {
             return false;
         }
         return stack.getFoodProperties(null) != null;
+    }
+    
+    private boolean hasAnyFood(Villager villager) {
+        SimpleContainer inventory = villager.getInventory();
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack item = inventory.getItem(i);
+            if (!item.isEmpty() && item.isEdible()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private int findFirstEmptySlot(Villager villager) {
+        SimpleContainer inventory = villager.getInventory();
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            if (inventory.getItem(i).isEmpty()) {
+                return i;
+            }
+        }
+        return -1;
     }
 }


### PR DESCRIPTION
# Expand villager inventory from 1 to 5 slots
Increases villager inventory capacity from 1 slot to 5 slots to support upcoming storage system where villagers will manage tools, food, seeds, and harvested items.

## Changes
- Expanded villager inventory from `SimpleContainer(1)` to `SimpleContainer(5)`
- Removed player interaction `mobInteract` method (will be replaced with proper GUI later)
- Updated save/load system to handle all 5 inventory slots with backwards compatibility
- Refactored EatFood behavior to use ItemMatcher and search all inventory slots for best food
- Updated FindFoodInStorageBehavior to place food in any available empty slot
- Updated death drops to drop all inventory items instead of just slot 0

## Related Issues
Resolves #39

## Implementation Notes
The save/load system maintains backwards compatibility - existing worlds with the old single-item format will still load correctly into slot 0, while new saves use a proper ListTag format. EatFood behavior now selects the best available food based on saturation value rather than just using whatever is in slot 0.

## Breaking Changes
Players can no longer give items directly to villagers by right-clicking - this functionality will be replaced with a proper inventory GUI in future updates.