### PR TITLE
Add ITEMS_TO_DEPOSIT memory module

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.resources.ResourceLocation;
@@ -60,6 +61,9 @@ public class MemoryModuleTypes {
 
     public static final RegistryObject<MemoryModuleType<FoundItem>> FOUND_ITEM =
         MEMORY_MODULE_TYPES.register("found_item", () -> new MemoryModuleType<>(Optional.empty()));
+
+    public static final RegistryObject<MemoryModuleType<Map<ResourceLocation, Integer>>> ITEMS_TO_DEPOSIT =
+        MEMORY_MODULE_TYPES.register("items_to_deposit", () -> new MemoryModuleType<>(Optional.empty()));
 
     public static void register(IEventBus eventBus) {
         MEMORY_MODULE_TYPES.register(eventBus);


### PR DESCRIPTION
# Add ITEMS_TO_DEPOSIT memory module
Implements a memory module for tracking items that should be deposited to storage containers.

## Changes
- Added Map import to MemoryModuleTypes.java
- Created ITEMS_TO_DEPOSIT memory module with Map<ResourceLocation, Integer> type
- Memory module does not auto-expire (cleared manually by behaviors)

## Related Issues
Resolves #52

## Implementation Notes
Uses Optional.empty() for codec to prevent auto-expiration, allowing behaviors to control when the memory is cleared after successful deposits.

## Breaking Changes
None