### PR TITLE
Add GoToNearestStorage behavior and zone improvements

### DIFF
--- a/src/main/java/org/sosly/villagetale/api/data/IVillageZone.java
+++ b/src/main/java/org/sosly/villagetale/api/data/IVillageZone.java
@@ -72,7 +72,7 @@ public interface IVillageZone {
     /**
      * Gets the starting/reference position for this zone.
      * @return Starting position - center for Radius, first position for Path,
-     *         the single position for BlockPos, calculated center for AABBZone
+     *         the single position for BlockPos, calculated center for AABB
      */
     BlockPos getStartPos();
 

--- a/src/main/java/org/sosly/villagetale/api/data/IVillageZone.java
+++ b/src/main/java/org/sosly/villagetale/api/data/IVillageZone.java
@@ -70,6 +70,13 @@ public interface IVillageZone {
     boolean containsPosition(BlockPos pos);
 
     /**
+     * Gets the starting/reference position for this zone.
+     * @return Starting position - center for Radius, first position for Path,
+     *         the single position for BlockPos, calculated center for AABBZone
+     */
+    BlockPos getStartPos();
+
+    /**
      * Serializes this zone's data to NBT for persistence.
      * @return CompoundTag containing all zone data
      */

--- a/src/main/java/org/sosly/villagetale/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villagetale/command/ZoneCommand.java
@@ -184,7 +184,7 @@ public class ZoneCommand {
             });
 
         } catch (Exception e) {
-            context.getSource().sendFailure(Component.literal("Failed to create AABBZone zone: " + e.getMessage()));
+            context.getSource().sendFailure(Component.literal("Failed to create AABB zone: " + e.getMessage()));
             return 0;
         }
     }

--- a/src/main/java/org/sosly/villagetale/command/ZoneCommand.java
+++ b/src/main/java/org/sosly/villagetale/command/ZoneCommand.java
@@ -29,7 +29,10 @@ import org.sosly.villagetale.command.arguments.VillageUUIDArgument;
 import org.sosly.villagetale.command.arguments.ZoneTypeArgument;
 import org.sosly.villagetale.command.arguments.ZoneUUIDArgument;
 import org.sosly.villagetale.data.VillageInfo;
-import org.sosly.villagetale.data.zones.PathVillageZone;
+import org.sosly.villagetale.data.zones.AABBZone;
+import org.sosly.villagetale.data.zones.BlockPosZone;
+import org.sosly.villagetale.data.zones.PathZone;
+import org.sosly.villagetale.data.zones.RadiusZone;
 import org.sosly.villagetale.data.zones.ZoneFactory;
 import org.sosly.villagetale.entity.Villager;
 
@@ -181,7 +184,7 @@ public class ZoneCommand {
             });
 
         } catch (Exception e) {
-            context.getSource().sendFailure(Component.literal("Failed to create AABB zone: " + e.getMessage()));
+            context.getSource().sendFailure(Component.literal("Failed to create AABBZone zone: " + e.getMessage()));
             return 0;
         }
     }
@@ -515,7 +518,7 @@ public class ZoneCommand {
                         .map(villageCapability -> {
                             List<IVillageZone> zones = villageCapability.getZones();
                             for (IVillageZone zone : zones) {
-                                if (zone.getUUID().equals(zoneId) && zone instanceof PathVillageZone pathZone) {
+                                if (zone.getUUID().equals(zoneId) && zone instanceof PathZone pathZone) {
                                     pathZone.addPoint(pos);
                                     source.sendSuccess(() ->
                                         Component.literal("Added point " + pos.toShortString() + " to path zone"), true);
@@ -558,7 +561,7 @@ public class ZoneCommand {
                         .map(villageCapability -> {
                             List<IVillageZone> zones = villageCapability.getZones();
                             for (IVillageZone zone : zones) {
-                                if (zone.getUUID().equals(zoneId) && zone instanceof PathVillageZone pathZone) {
+                                if (zone.getUUID().equals(zoneId) && zone instanceof PathZone pathZone) {
                                     pathZone.clearPath();
                                     source.sendSuccess(() ->
                                         Component.literal("Cleared path zone"), true);
@@ -616,20 +619,20 @@ public class ZoneCommand {
     }
 
     private static void showZoneBounds(CommandSourceStack source, IVillageZone zone) {
-        if (zone instanceof org.sosly.villagetale.data.zones.AABBVillageZone aabbZone) {
+        if (zone instanceof AABBZone aabbZone) {
             var bounds = aabbZone.getAABB();
             source.sendSuccess(() ->
                 Component.literal("Bounds: (" + (int)bounds.minX + ", " + (int)bounds.minY + ", " + (int)bounds.minZ +
                                ") to (" + (int)bounds.maxX + ", " + (int)bounds.maxY + ", " + (int)bounds.maxZ + ")"), false);
-        } else if (zone instanceof org.sosly.villagetale.data.zones.RadiusVillageZone radiusZone) {
+        } else if (zone instanceof RadiusZone radiusZone) {
             var center = radiusZone.getCenter();
             source.sendSuccess(() ->
                 Component.literal("Center: " + center.toShortString() + ", Radius: " + radiusZone.getRadius()), false);
-        } else if (zone instanceof org.sosly.villagetale.data.zones.BlockPosVillageZone blockPosZone) {
+        } else if (zone instanceof BlockPosZone blockPosZone) {
             var pos = blockPosZone.getBlockPos();
             source.sendSuccess(() ->
                 Component.literal("Position: " + pos.toShortString()), false);
-        } else if (zone instanceof org.sosly.villagetale.data.zones.PathVillageZone pathZone) {
+        } else if (zone instanceof PathZone pathZone) {
             var path = pathZone.getPath();
             if (path.isEmpty()) {
                 source.sendSuccess(() ->

--- a/src/main/java/org/sosly/villagetale/data/zones/AABBZone.java
+++ b/src/main/java/org/sosly/villagetale/data/zones/AABBZone.java
@@ -7,42 +7,41 @@ import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.AABB;
 import org.sosly.villagetale.api.data.ZoneShape;
 import org.sosly.villagetale.api.data.ZoneType;
 
-public class AABBVillageZone extends AbstractVillageZone {
+public class AABBZone extends AbstractVillageZone {
 
-    private AABB bounds;
+    private net.minecraft.world.phys.AABB bounds;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
-    public AABBVillageZone(UUID uuid, ZoneType type, String name, AABB bounds, Level level) {
+    public AABBZone(UUID uuid, ZoneType type, String name, net.minecraft.world.phys.AABB bounds, Level level) {
         super(uuid, type, name, level);
         this.bounds = bounds;
     }
 
-    public AABBVillageZone(UUID uuid, ZoneType type, String name, AABB bounds) {
+    public AABBZone(UUID uuid, ZoneType type, String name, net.minecraft.world.phys.AABB bounds) {
         super(uuid, type, name);
         this.bounds = bounds;
     }
 
-    public AABBVillageZone(UUID uuid, ZoneType type, int id, String name, AABB bounds, Level level) {
+    public AABBZone(UUID uuid, ZoneType type, int id, String name, net.minecraft.world.phys.AABB bounds, Level level) {
         super(uuid, type, id, name, level);
         this.bounds = bounds;
     }
 
-    public AABBVillageZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
+    public AABBZone(UUID uuid, ZoneType type, int id, String name, net.minecraft.world.phys.AABB bounds) {
         super(uuid, type, id, name);
         this.bounds = bounds;
     }
 
 
-    public AABB getAABB() {
+    public net.minecraft.world.phys.AABB getAABB() {
         return bounds;
     }
 
-    public void setAABB(AABB bounds) {
+    public void setAABB(net.minecraft.world.phys.AABB bounds) {
         this.bounds = bounds;
         this.poiCacheDirty = true;
     }
@@ -133,7 +132,7 @@ public class AABBVillageZone extends AbstractVillageZone {
 
         if (tag.contains("Bounds")) {
             CompoundTag boundsTag = tag.getCompound("Bounds");
-            this.bounds = new AABB(
+            this.bounds = new net.minecraft.world.phys.AABB(
                 boundsTag.getDouble("MinX"),
                 boundsTag.getDouble("MinY"),
                 boundsTag.getDouble("MinZ"),
@@ -144,5 +143,10 @@ public class AABBVillageZone extends AbstractVillageZone {
         }
 
         this.poiCacheDirty = true;
+    }
+
+    @Override
+    public BlockPos getStartPos() {
+        return BlockPos.containing(bounds.getCenter());
     }
 }

--- a/src/main/java/org/sosly/villagetale/data/zones/BlockPosZone.java
+++ b/src/main/java/org/sosly/villagetale/data/zones/BlockPosZone.java
@@ -10,26 +10,26 @@ import net.minecraft.world.level.Level;
 import org.sosly.villagetale.api.data.ZoneShape;
 import org.sosly.villagetale.api.data.ZoneType;
 
-public class BlockPosVillageZone extends AbstractVillageZone {
+public class BlockPosZone extends AbstractVillageZone {
 
     private BlockPos blockPos;
 
-    public BlockPosVillageZone(UUID uuid, ZoneType type, String name, BlockPos blockPos, Level level) {
+    public BlockPosZone(UUID uuid, ZoneType type, String name, BlockPos blockPos, Level level) {
         super(uuid, type, name, level);
         this.blockPos = blockPos;
     }
 
-    public BlockPosVillageZone(UUID uuid, ZoneType type, String name, BlockPos blockPos) {
+    public BlockPosZone(UUID uuid, ZoneType type, String name, BlockPos blockPos) {
         super(uuid, type, name);
         this.blockPos = blockPos;
     }
 
-    public BlockPosVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos, Level level) {
+    public BlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos, Level level) {
         super(uuid, type, id, name, level);
         this.blockPos = blockPos;
     }
 
-    public BlockPosVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos) {
+    public BlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos blockPos) {
         super(uuid, type, id, name);
         this.blockPos = blockPos;
     }
@@ -91,5 +91,10 @@ public class BlockPosVillageZone extends AbstractVillageZone {
         if (tag.contains("BlockPos")) {
             this.blockPos = BlockPos.of(tag.getLong("BlockPos"));
         }
+    }
+
+    @Override
+    public BlockPos getStartPos() {
+        return this.blockPos;
     }
 }

--- a/src/main/java/org/sosly/villagetale/data/zones/PathZone.java
+++ b/src/main/java/org/sosly/villagetale/data/zones/PathZone.java
@@ -13,28 +13,28 @@ import net.minecraft.world.level.Level;
 import org.sosly.villagetale.api.data.ZoneShape;
 import org.sosly.villagetale.api.data.ZoneType;
 
-public class PathVillageZone extends AbstractVillageZone {
+public class PathZone extends AbstractVillageZone {
 
     private List<BlockPos> path;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
-    public PathVillageZone(UUID uuid, ZoneType type, String name, List<BlockPos> path, Level level) {
+    public PathZone(UUID uuid, ZoneType type, String name, List<BlockPos> path, Level level) {
         super(uuid, type, name, level);
         this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
     }
 
-    public PathVillageZone(UUID uuid, ZoneType type, String name, List<BlockPos> path) {
+    public PathZone(UUID uuid, ZoneType type, String name, List<BlockPos> path) {
         super(uuid, type, name);
         this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
     }
 
-    public PathVillageZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path, Level level) {
+    public PathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path, Level level) {
         super(uuid, type, id, name, level);
         this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
     }
 
-    public PathVillageZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
+    public PathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
         super(uuid, type, id, name);
         this.path = new ArrayList<>(path != null ? path : new ArrayList<>());
     }
@@ -132,5 +132,13 @@ public class PathVillageZone extends AbstractVillageZone {
             }
         }
         this.poiCacheDirty = true;
+    }
+
+    @Override
+    public BlockPos getStartPos() {
+        if (path.isEmpty()) {
+            return BlockPos.ZERO;
+        }
+        return path.get(0);
     }
 }

--- a/src/main/java/org/sosly/villagetale/data/zones/RadiusZone.java
+++ b/src/main/java/org/sosly/villagetale/data/zones/RadiusZone.java
@@ -10,32 +10,32 @@ import net.minecraft.world.level.Level;
 import org.sosly.villagetale.api.data.ZoneShape;
 import org.sosly.villagetale.api.data.ZoneType;
 
-public class RadiusVillageZone extends AbstractVillageZone {
+public class RadiusZone extends AbstractVillageZone {
 
     private BlockPos center;
     private int radius;
     private List<BlockPos> cachedPOIs;
     private boolean poiCacheDirty = true;
 
-    public RadiusVillageZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius, Level level) {
+    public RadiusZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius, Level level) {
         super(uuid, type, name, level);
         this.center = center;
         this.radius = radius;
     }
 
-    public RadiusVillageZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius) {
+    public RadiusZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius) {
         super(uuid, type, name);
         this.center = center;
         this.radius = radius;
     }
 
-    public RadiusVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
+    public RadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
         super(uuid, type, id, name, level);
         this.center = center;
         this.radius = radius;
     }
 
-    public RadiusVillageZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
+    public RadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
         super(uuid, type, id, name);
         this.center = center;
         this.radius = radius;
@@ -139,5 +139,10 @@ public class RadiusVillageZone extends AbstractVillageZone {
         }
         this.radius = tag.getInt("Radius");
         this.poiCacheDirty = true;
+    }
+
+    @Override
+    public BlockPos getStartPos() {
+        return this.center;
     }
 }

--- a/src/main/java/org/sosly/villagetale/data/zones/ZoneFactory.java
+++ b/src/main/java/org/sosly/villagetale/data/zones/ZoneFactory.java
@@ -8,7 +8,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.AABB;
 import org.sosly.villagetale.api.data.IVillageZone;
 import org.sosly.villagetale.api.data.ZoneShape;
 import org.sosly.villagetale.api.data.ZoneType;
@@ -26,24 +25,24 @@ public class ZoneFactory {
 
     public static IVillageZone createZone(ZoneShape shape, UUID uuid, ZoneType type, String name) {
         return switch (shape) {
-            case AABB -> new AABBVillageZone(uuid, type, name, new AABB(0, 0, 0, 1, 1, 1));
-            case RADIUS -> new RadiusVillageZone(uuid, type, name, BlockPos.ZERO, 1);
-            case BLOCKPOS -> new BlockPosVillageZone(uuid, type, name, BlockPos.ZERO);
-            case PATH -> new PathVillageZone(uuid, type, name, new ArrayList<>());
+            case AABB -> new AABBZone(uuid, type, name, new net.minecraft.world.phys.AABB(0, 0, 0, 1, 1, 1));
+            case RADIUS -> new RadiusZone(uuid, type, name, BlockPos.ZERO, 1);
+            case BLOCKPOS -> new BlockPosZone(uuid, type, name, BlockPos.ZERO);
+            case PATH -> new PathZone(uuid, type, name, new ArrayList<>());
         };
     }
 
-    public static IVillageZone createAABBZone(ZoneType type, String name, AABB bounds, Level level) {
+    public static IVillageZone createAABBZone(ZoneType type, String name, net.minecraft.world.phys.AABB bounds, Level level) {
         UUID uuid = UUID.randomUUID();
         return createAABBZone(uuid, type, name, bounds, level);
     }
 
-    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, String name, AABB bounds, Level level) {
-        return new AABBVillageZone(uuid, type, name, bounds, level);
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, String name, net.minecraft.world.phys.AABB bounds, Level level) {
+        return new AABBZone(uuid, type, name, bounds, level);
     }
 
-    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, String name, AABB bounds) {
-        return new AABBVillageZone(uuid, type, name, bounds);
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, String name, net.minecraft.world.phys.AABB bounds) {
+        return new AABBZone(uuid, type, name, bounds);
     }
 
     public static IVillageZone createRadiusZone(ZoneType type, String name, BlockPos center, int radius, Level level) {
@@ -52,11 +51,11 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius, Level level) {
-        return new RadiusVillageZone(uuid, type, name, center, radius, level);
+        return new RadiusZone(uuid, type, name, center, radius, level);
     }
 
     public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, String name, BlockPos center, int radius) {
-        return new RadiusVillageZone(uuid, type, name, center, radius);
+        return new RadiusZone(uuid, type, name, center, radius);
     }
 
     public static IVillageZone createBlockPosZone(ZoneType type, String name, BlockPos pos, Level level) {
@@ -65,7 +64,7 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createBlockPosZone(UUID uuid, ZoneType type, String name, BlockPos pos, Level level) {
-        return new BlockPosVillageZone(uuid, type, name, pos, level);
+        return new BlockPosZone(uuid, type, name, pos, level);
     }
 
     public static IVillageZone createPathZone(ZoneType type, String name, List<BlockPos> path, Level level) {
@@ -74,11 +73,11 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createPathZone(UUID uuid, ZoneType type, String name, List<BlockPos> path, Level level) {
-        return new PathVillageZone(uuid, type, name, path != null ? path : new ArrayList<>(), level);
+        return new PathZone(uuid, type, name, path != null ? path : new ArrayList<>(), level);
     }
 
     public static IVillageZone createPathZone(UUID uuid, ZoneType type, String name, List<BlockPos> path) {
-        return new PathVillageZone(uuid, type, name, path != null ? path : new ArrayList<>());
+        return new PathZone(uuid, type, name, path != null ? path : new ArrayList<>());
     }
 
 
@@ -89,24 +88,24 @@ public class ZoneFactory {
 
     public static IVillageZone createZone(ZoneShape shape, UUID uuid, ZoneType type, int id, String name) {
         return switch (shape) {
-            case AABB -> new AABBVillageZone(uuid, type, id, name, new AABB(0, 0, 0, 1, 1, 1));
-            case RADIUS -> new RadiusVillageZone(uuid, type, id, name, BlockPos.ZERO, 1);
-            case BLOCKPOS -> new BlockPosVillageZone(uuid, type, id, name, BlockPos.ZERO);
-            case PATH -> new PathVillageZone(uuid, type, id, name, new ArrayList<>());
+            case AABB -> new AABBZone(uuid, type, id, name, new net.minecraft.world.phys.AABB(0, 0, 0, 1, 1, 1));
+            case RADIUS -> new RadiusZone(uuid, type, id, name, BlockPos.ZERO, 1);
+            case BLOCKPOS -> new BlockPosZone(uuid, type, id, name, BlockPos.ZERO);
+            case PATH -> new PathZone(uuid, type, id, name, new ArrayList<>());
         };
     }
 
-    public static IVillageZone createAABBZone(ZoneType type, int id, String name, AABB bounds, Level level) {
+    public static IVillageZone createAABBZone(ZoneType type, int id, String name, net.minecraft.world.phys.AABB bounds, Level level) {
         UUID uuid = UUID.randomUUID();
         return createAABBZone(uuid, type, id, name, bounds, level);
     }
 
-    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, AABB bounds, Level level) {
-        return new AABBVillageZone(uuid, type, id, name, bounds, level);
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, net.minecraft.world.phys.AABB bounds, Level level) {
+        return new AABBZone(uuid, type, id, name, bounds, level);
     }
 
-    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, AABB bounds) {
-        return new AABBVillageZone(uuid, type, id, name, bounds);
+    public static IVillageZone createAABBZone(UUID uuid, ZoneType type, int id, String name, net.minecraft.world.phys.AABB bounds) {
+        return new AABBZone(uuid, type, id, name, bounds);
     }
 
     public static IVillageZone createRadiusZone(ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
@@ -115,11 +114,11 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius, Level level) {
-        return new RadiusVillageZone(uuid, type, id, name, center, radius, level);
+        return new RadiusZone(uuid, type, id, name, center, radius, level);
     }
 
     public static IVillageZone createRadiusZone(UUID uuid, ZoneType type, int id, String name, BlockPos center, int radius) {
-        return new RadiusVillageZone(uuid, type, id, name, center, radius);
+        return new RadiusZone(uuid, type, id, name, center, radius);
     }
 
     public static IVillageZone createBlockPosZone(ZoneType type, int id, String name, BlockPos pos, Level level) {
@@ -128,7 +127,7 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createBlockPosZone(UUID uuid, ZoneType type, int id, String name, BlockPos pos, Level level) {
-        return new BlockPosVillageZone(uuid, type, id, name, pos, level);
+        return new BlockPosZone(uuid, type, id, name, pos, level);
     }
 
     public static IVillageZone createPathZone(ZoneType type, int id, String name, List<BlockPos> path, Level level) {
@@ -137,11 +136,11 @@ public class ZoneFactory {
     }
 
     public static IVillageZone createPathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path, Level level) {
-        return new PathVillageZone(uuid, type, id, name, path != null ? path : new ArrayList<>(), level);
+        return new PathZone(uuid, type, id, name, path != null ? path : new ArrayList<>(), level);
     }
 
     public static IVillageZone createPathZone(UUID uuid, ZoneType type, int id, String name, List<BlockPos> path) {
-        return new PathVillageZone(uuid, type, id, name, path != null ? path : new ArrayList<>());
+        return new PathZone(uuid, type, id, name, path != null ? path : new ArrayList<>());
     }
 
     public static IVillageZone deserializeFromNBT(CompoundTag tag) {

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorageBehavior.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorageBehavior.java
@@ -25,6 +25,8 @@ import org.sosly.villagetale.entity.Villager;
 public class GoToNearestStorageBehavior extends Behavior<Villager> {
     private static final int BEHAVIOR_DURATION = 60;
 
+    private BlockPos targetStoragePos;
+
     public GoToNearestStorageBehavior() {
         super(ImmutableMap.of(
             MemoryModuleTypes.VILLAGE.get(), MemoryStatus.VALUE_PRESENT,
@@ -78,8 +80,6 @@ public class GoToNearestStorageBehavior extends Behavior<Villager> {
             }
         }
     }
-
-    private BlockPos targetStoragePos;
 
     private BlockPos findNearestStorage(ServerLevel level, Villager villager, UUID villageId, boolean excludeScanned) {
         IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorageBehavior.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorageBehavior.java
@@ -1,0 +1,137 @@
+package org.sosly.villagetale.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.api.capability.IVillagesCapability;
+import org.sosly.villagetale.api.data.IVillageZone;
+import org.sosly.villagetale.api.data.ZoneType;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+
+public class GoToNearestStorageBehavior extends Behavior<Villager> {
+    private static final int BEHAVIOR_DURATION = 60;
+
+    public GoToNearestStorageBehavior() {
+        super(ImmutableMap.of(
+            MemoryModuleTypes.VILLAGE.get(), MemoryStatus.VALUE_PRESENT,
+            MemoryModuleType.WALK_TARGET, MemoryStatus.VALUE_ABSENT
+        ), BEHAVIOR_DURATION);
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        if (villager.getBrain().hasMemoryValue(MemoryModuleTypes.FOUND_ITEM.get())) {
+            return false;
+        }
+
+        boolean hasWantedItem = villager.getBrain().hasMemoryValue(MemoryModuleTypes.WANTED_ITEM.get());
+        boolean hasItemsToDeposit = villager.getBrain().hasMemoryValue(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get());
+
+        if (!hasWantedItem && !hasItemsToDeposit) {
+            return false;
+        }
+
+        UUID villageId = villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null);
+        if (villageId == null) {
+            return false;
+        }
+
+        boolean excludeScanned = hasWantedItem;
+        BlockPos targetStorage = findNearestStorage(level, villager, villageId, excludeScanned);
+
+        if (targetStorage == null && excludeScanned) {
+            villager.getBrain().eraseMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get());
+            targetStorage = findNearestStorage(level, villager, villageId, false);
+        }
+
+        if (targetStorage == null) {
+            return false;
+        }
+
+        this.targetStoragePos = targetStorage;
+        return true;
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        if (this.targetStoragePos != null) {
+            villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+                new WalkTarget(this.targetStoragePos, 0.5F, 2));
+
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("GoToNearestStorage set walk target to {} for villager {}",
+                    this.targetStoragePos, villager.getId());
+            }
+        }
+    }
+
+    private BlockPos targetStoragePos;
+
+    private BlockPos findNearestStorage(ServerLevel level, Villager villager, UUID villageId, boolean excludeScanned) {
+        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return null;
+        }
+
+        VillageInfo village = villagesCapability.getVillageById(villageId);
+        if (village == null) {
+            return null;
+        }
+
+        ChunkPos townHallChunk = new ChunkPos(village.getTownHallPos());
+        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
+
+        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            return null;
+        }
+
+        List<IVillageZone> zones = villageCapability.getZones();
+        BlockPos villagerPos = villager.blockPosition();
+        BlockPos nearestZoneCenter = null;
+        double nearestDistance = Double.MAX_VALUE;
+
+        List<UUID> scannedStorages = excludeScanned ?
+            villager.getBrain().getMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get()).orElse(List.of()) :
+            List.of();
+
+        for (IVillageZone zone : zones) {
+            if (zone.getType() != ZoneType.STORAGE) {
+                continue;
+            }
+
+            if (excludeScanned && scannedStorages.contains(zone.getUUID())) {
+                continue;
+            }
+
+            Optional<List<BlockPos>> pois = zone.getPOIs();
+            if (pois.isEmpty()) {
+                continue;
+            }
+
+            BlockPos zoneStart = zone.getStartPos();
+            double distance = villagerPos.distSqr(zoneStart);
+
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearestZoneCenter = zoneStart;
+            }
+        }
+
+        return nearestZoneCenter;
+    }
+}


### PR DESCRIPTION
# Add GoToNearestStorage behavior and zone improvements
Implements navigation behavior for villagers to reach storage zones when fetching or depositing items.

## Changes
- **GoToNearestStorageBehavior**: Navigates to nearest storage based on WANTED_ITEM or ITEMS_TO_DEPOSIT memory
- **Zone interface enhancement**: Added getStartPos() method for semantic zone positioning
- **Zone class renames**: Simplified naming from *VillageZone to *Zone
- **Smart storage selection**: Excludes already-scanned storages when fetching, includes all when depositing

## Related Issues
Resolves #46

## Implementation Notes
Uses zone start positions instead of calculating centers from POIs for more predictable targeting. Behavior intelligently handles both item fetching (with scan tracking) and depositing (no scan tracking) modes.

## Zone getStartPos() implementations
- **BlockPosZone**: Returns the single position
- **RadiusZone**: Returns center position  
- **AABBZone**: Returns calculated center
- **PathZone**: Returns first position in path

## Breaking Changes
Zone class names changed (AABBVillageZone → AABBZone, etc.)