### PR TITLE
Add IsItemInStorage sensor and refactor sensor naming

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
@@ -6,26 +6,30 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villagetale.VillageTale;
-import org.sosly.villagetale.entity.ai.sensor.HasFoodSensor;
-import org.sosly.villagetale.entity.ai.sensor.HasResourceSensor;
-import org.sosly.villagetale.entity.ai.sensor.HasToolSensor;
-import org.sosly.villagetale.entity.ai.sensor.HungerSensor;
+import org.sosly.villagetale.entity.ai.sensor.HasFood;
+import org.sosly.villagetale.entity.ai.sensor.HasResources;
+import org.sosly.villagetale.entity.ai.sensor.HasTool;
+import org.sosly.villagetale.entity.ai.sensor.IsHungry;
+import org.sosly.villagetale.entity.ai.sensor.IsItemInStorage;
 
 public class SensorTypes {
     public static final DeferredRegister<SensorType<?>> SENSOR_TYPES =
         DeferredRegister.create(ForgeRegistries.SENSOR_TYPES, VillageTale.MOD_ID);
 
-    public static final RegistryObject<SensorType<HungerSensor>> HUNGER =
-        SENSOR_TYPES.register("hunger", () -> new SensorType<>(HungerSensor::new));
+    public static final RegistryObject<SensorType<IsHungry>> HUNGER =
+        SENSOR_TYPES.register("hunger", () -> new SensorType<>(IsHungry::new));
 
-    public static final RegistryObject<SensorType<HasFoodSensor>> HAS_FOOD =
-        SENSOR_TYPES.register("has_food", () -> new SensorType<>(HasFoodSensor::new));
+    public static final RegistryObject<SensorType<HasFood>> HAS_FOOD =
+        SENSOR_TYPES.register("has_food", () -> new SensorType<>(HasFood::new));
 
-    public static final RegistryObject<SensorType<HasToolSensor>> HAS_TOOL =
-        SENSOR_TYPES.register("has_tool", () -> new SensorType<>(HasToolSensor::new));
+    public static final RegistryObject<SensorType<HasTool>> HAS_TOOL =
+        SENSOR_TYPES.register("has_tool", () -> new SensorType<>(HasTool::new));
 
-    public static final RegistryObject<SensorType<HasResourceSensor>> HAS_RESOURCE =
-        SENSOR_TYPES.register("has_resource", () -> new SensorType<>(HasResourceSensor::new));
+    public static final RegistryObject<SensorType<HasResources>> HAS_RESOURCE =
+        SENSOR_TYPES.register("has_resource", () -> new SensorType<>(HasResources::new));
+
+    public static final RegistryObject<SensorType<IsItemInStorage>> SEARCH_STORAGE_FOR_ITEM =
+        SENSOR_TYPES.register("search_storage_for_item", () -> new SensorType<>(IsItemInStorage::new));
 
     public static void register(IEventBus eventBus) {
         SENSOR_TYPES.register(eventBus);

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasFood.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasFood.java
@@ -8,14 +8,13 @@ import net.minecraft.world.item.ItemStack;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
-import org.sosly.villagetale.data.WantedItem;
 import org.sosly.villagetale.helper.ItemMatcher;
 
 import java.util.Set;
 
-public class HasFoodSensor extends Sensor<Villager> {
+public class HasFood extends Sensor<Villager> {
 
-    public HasFoodSensor() {
+    public HasFood() {
         super(200);
     }
 
@@ -32,9 +31,9 @@ public class HasFoodSensor extends Sensor<Villager> {
             villager.getBrain().setMemory(MemoryModuleTypes.WANTED_ITEM.get(), ItemMatcher.FOOD.getFor(villager));
             villager.getBrain().eraseMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get());
             villager.getBrain().eraseMemory(MemoryModuleTypes.FOUND_ITEM.get());
-            
+
             if (VillageTale.LOGGER.isDebugEnabled()) {
-                VillageTale.LOGGER.debug("HasFoodSensor set WANTED_ITEM to FOOD for villager {}", villager.getId());
+                VillageTale.LOGGER.debug("HasFood set WANTED_ITEM to FOOD for villager {}", villager.getId());
             }
             return;
         }
@@ -49,9 +48,9 @@ public class HasFoodSensor extends Sensor<Villager> {
         }
 
         villager.getBrain().eraseMemory(MemoryModuleTypes.WANTED_ITEM.get());
-        
+
         if (VillageTale.LOGGER.isDebugEnabled()) {
-            VillageTale.LOGGER.debug("HasFoodSensor cleared WANTED_ITEM for villager {}", villager.getId());
+            VillageTale.LOGGER.debug("HasFood cleared WANTED_ITEM for villager {}", villager.getId());
         }
     }
 

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasItemsToDeposit.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasItemsToDeposit.java
@@ -16,12 +16,12 @@ import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.helper.ItemMatcher;
 
-public class HasItemsToDepositSensor extends Sensor<Villager> {
+public class HasItemsToDeposit extends Sensor<Villager> {
     private static final int NEARLY_FULL_THRESHOLD = 4;
     private static final int LARGE_QUANTITY_THRESHOLD = 32;
     private static final int FOOD_TO_KEEP = 3;
 
-    public HasItemsToDepositSensor() {
+    public HasItemsToDeposit() {
         super(200);
     }
 
@@ -44,7 +44,7 @@ public class HasItemsToDepositSensor extends Sensor<Villager> {
         villager.getBrain().setMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get(), itemsToDeposit);
 
         if (VillageTale.LOGGER.isDebugEnabled()) {
-            VillageTale.LOGGER.debug("HasItemsToDepositSensor set ITEMS_TO_DEPOSIT for villager {} with {} items",
+            VillageTale.LOGGER.debug("HasItemsToDeposit set ITEMS_TO_DEPOSIT for villager {} with {} items",
                 villager.getId(), itemsToDeposit.size());
         }
     }

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasResources.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasResources.java
@@ -1,6 +1,7 @@
 package org.sosly.villagetale.entity.ai.sensor;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
@@ -9,63 +10,68 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.data.IWantedItem;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
-import org.sosly.villagetale.data.WantedItem;
 import org.sosly.villagetale.helper.ItemMatcher;
 
-import java.util.Set;
+public class HasResources extends Sensor<Villager> {
 
-public class HasToolSensor extends Sensor<Villager> {
 
-    public HasToolSensor() {
+    public HasResources() {
         super(200);
     }
 
     @Override
     protected void doTick(ServerLevel level, Villager villager) {
-        IWantedItem requiredTool = villager.getProfession().getTool().orElse(null);
-        
-        if (requiredTool == null || requiredTool == IWantedItem.EMPTY) {
+        IWantedItem requiredResources = villager.getProfession().getAlwaysWantedItems().orElse(null);
+
+        if (requiredResources == null || requiredResources == IWantedItem.EMPTY) {
             return;
         }
 
-        boolean hasTool = hasTool(villager, requiredTool);
+        int resourceCount = countResources(villager, requiredResources);
+        int minimumThreshold = requiredResources.getMinimum();
+        int targetAmount = requiredResources.getAmount();
+        boolean needsMoreResources = resourceCount < minimumThreshold;
+        boolean hasTargetAmount = resourceCount >= targetAmount;
         boolean hasExistingWant = villager.getBrain().hasMemoryValue(MemoryModuleTypes.WANTED_ITEM.get());
 
-        if (!hasTool && !hasExistingWant) {
-            villager.getBrain().setMemory(MemoryModuleTypes.WANTED_ITEM.get(), ItemMatcher.PROFESSION_TOOL.getFor(villager));
+        if (needsMoreResources && !hasExistingWant) {
+            villager.getBrain().setMemory(MemoryModuleTypes.WANTED_ITEM.get(), ItemMatcher.RESOURCES.getFor(villager));
             villager.getBrain().eraseMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get());
             villager.getBrain().eraseMemory(MemoryModuleTypes.FOUND_ITEM.get());
-            
+
             if (VillageTale.LOGGER.isDebugEnabled()) {
-                VillageTale.LOGGER.debug("HasToolSensor set WANTED_ITEM to PROFESSION_TOOL for villager {}", villager.getId());
+                VillageTale.LOGGER.debug("HasResources set WANTED_ITEM to RESOURCES for villager {} (has {}, need >= {})",
+                    villager.getId(), resourceCount, minimumThreshold);
             }
             return;
         }
 
-        if (!hasTool || !hasExistingWant) {
+        if (!hasTargetAmount || !hasExistingWant) {
             return;
         }
 
         var currentWant = villager.getBrain().getMemory(MemoryModuleTypes.WANTED_ITEM.get()).orElse(null);
-        if (currentWant == null || !currentWant.equals(ItemMatcher.PROFESSION_TOOL.getFor(villager))) {
+        if (currentWant == null || !currentWant.equals(ItemMatcher.RESOURCES.getFor(villager))) {
             return;
         }
 
         villager.getBrain().eraseMemory(MemoryModuleTypes.WANTED_ITEM.get());
-        
+
         if (VillageTale.LOGGER.isDebugEnabled()) {
-            VillageTale.LOGGER.debug("HasToolSensor cleared WANTED_ITEM for villager {}", villager.getId());
+            VillageTale.LOGGER.debug("HasResources cleared WANTED_ITEM for villager {} (has {}, reached target {})",
+                villager.getId(), resourceCount, targetAmount);
         }
     }
 
-    private boolean hasTool(Villager villager, IWantedItem requiredTool) {
+    private int countResources(Villager villager, IWantedItem requiredResources) {
+        int count = 0;
         for (int i = 0; i < villager.getInventory().getContainerSize(); i++) {
             ItemStack stack = villager.getInventory().getItem(i);
-            if (!stack.isEmpty() && requiredTool.getMatcher().test(stack)) {
-                return true;
+            if (!stack.isEmpty() && requiredResources.getMatcher().test(stack)) {
+                count += stack.getCount();
             }
         }
-        return false;
+        return count;
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasTool.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasTool.java
@@ -1,7 +1,6 @@
 package org.sosly.villagetale.entity.ai.sensor;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
@@ -12,66 +11,60 @@ import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.helper.ItemMatcher;
 
-public class HasResourceSensor extends Sensor<Villager> {
+import java.util.Set;
 
+public class HasTool extends Sensor<Villager> {
 
-    public HasResourceSensor() {
+    public HasTool() {
         super(200);
     }
 
     @Override
     protected void doTick(ServerLevel level, Villager villager) {
-        IWantedItem requiredResources = villager.getProfession().getAlwaysWantedItems().orElse(null);
+        IWantedItem requiredTool = villager.getProfession().getTool().orElse(null);
 
-        if (requiredResources == null || requiredResources == IWantedItem.EMPTY) {
+        if (requiredTool == null || requiredTool == IWantedItem.EMPTY) {
             return;
         }
 
-        int resourceCount = countResources(villager, requiredResources);
-        int minimumThreshold = requiredResources.getMinimum();
-        int targetAmount = requiredResources.getAmount();
-        boolean needsMoreResources = resourceCount < minimumThreshold;
-        boolean hasTargetAmount = resourceCount >= targetAmount;
+        boolean hasTool = hasTool(villager, requiredTool);
         boolean hasExistingWant = villager.getBrain().hasMemoryValue(MemoryModuleTypes.WANTED_ITEM.get());
 
-        if (needsMoreResources && !hasExistingWant) {
-            villager.getBrain().setMemory(MemoryModuleTypes.WANTED_ITEM.get(), ItemMatcher.RESOURCES.getFor(villager));
+        if (!hasTool && !hasExistingWant) {
+            villager.getBrain().setMemory(MemoryModuleTypes.WANTED_ITEM.get(), ItemMatcher.PROFESSION_TOOL.getFor(villager));
             villager.getBrain().eraseMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get());
             villager.getBrain().eraseMemory(MemoryModuleTypes.FOUND_ITEM.get());
 
             if (VillageTale.LOGGER.isDebugEnabled()) {
-                VillageTale.LOGGER.debug("HasResourceSensor set WANTED_ITEM to RESOURCES for villager {} (has {}, need >= {})",
-                    villager.getId(), resourceCount, minimumThreshold);
+                VillageTale.LOGGER.debug("HasTool set WANTED_ITEM to PROFESSION_TOOL for villager {}", villager.getId());
             }
             return;
         }
 
-        if (!hasTargetAmount || !hasExistingWant) {
+        if (!hasTool || !hasExistingWant) {
             return;
         }
 
         var currentWant = villager.getBrain().getMemory(MemoryModuleTypes.WANTED_ITEM.get()).orElse(null);
-        if (currentWant == null || !currentWant.equals(ItemMatcher.RESOURCES.getFor(villager))) {
+        if (currentWant == null || !currentWant.equals(ItemMatcher.PROFESSION_TOOL.getFor(villager))) {
             return;
         }
 
         villager.getBrain().eraseMemory(MemoryModuleTypes.WANTED_ITEM.get());
 
         if (VillageTale.LOGGER.isDebugEnabled()) {
-            VillageTale.LOGGER.debug("HasResourceSensor cleared WANTED_ITEM for villager {} (has {}, reached target {})",
-                villager.getId(), resourceCount, targetAmount);
+            VillageTale.LOGGER.debug("HasTool cleared WANTED_ITEM for villager {}", villager.getId());
         }
     }
 
-    private int countResources(Villager villager, IWantedItem requiredResources) {
-        int count = 0;
+    private boolean hasTool(Villager villager, IWantedItem requiredTool) {
         for (int i = 0; i < villager.getInventory().getContainerSize(); i++) {
             ItemStack stack = villager.getInventory().getItem(i);
-            if (!stack.isEmpty() && requiredResources.getMatcher().test(stack)) {
-                count += stack.getCount();
+            if (!stack.isEmpty() && requiredTool.getMatcher().test(stack)) {
+                return true;
             }
         }
-        return count;
+        return false;
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsHungry.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsHungry.java
@@ -10,13 +10,13 @@ import org.sosly.villagetale.entity.Villager;
 
 import java.util.Set;
 
-public class HungerSensor extends Sensor<Villager> {
+public class IsHungry extends Sensor<Villager> {
 
     private static final int MAX_FOOD_LEVEL = 20;
     private static final int HUNGRY_THRESHOLD = 12;
     private static final int STARVING_THRESHOLD = 6;
 
-    public HungerSensor() {
+    public IsHungry() {
         super(600);
     }
 
@@ -33,7 +33,7 @@ public class HungerSensor extends Sensor<Villager> {
         updateMemoryIfChanged(villager, MemoryModuleTypes.IS_STARVING.get(), isStarving);
 
         if (VillageTale.LOGGER.isDebugEnabled()) {
-            VillageTale.LOGGER.debug("HungerSensor for villager {}: foodLevel={}, canEat={}, isHungry={}, isStarving={}",
+            VillageTale.LOGGER.debug("IsHungry for villager {}: foodLevel={}, canEat={}, isHungry={}, isStarving={}",
                 villager.getId(), foodLevel, canEat, isHungry, isStarving);
         }
     }

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsItemInStorage.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsItemInStorage.java
@@ -98,27 +98,24 @@ public class IsItemInStorage extends Sensor<Villager> {
         }
 
         for (BlockPos containerPos : pois.get()) {
-            if (ContainerHelper.hasMatchingItem(level, containerPos, wantedItem.getMatcher())) {
-                ResourceLocation itemId = findMatchingItemId(level, containerPos, wantedItem);
-                if (itemId != null) {
-                    FoundItem foundItem = new FoundItem(containerPos, itemId);
-                    villager.getBrain().setMemory(MemoryModuleTypes.FOUND_ITEM.get(), foundItem);
-
-                    if (VillageTale.LOGGER.isDebugEnabled()) {
-                        VillageTale.LOGGER.debug("IsItemInStorage found item {} at {} for villager {}",
-                            itemId, containerPos, villager.getId());
-                    }
-                    return;
-                }
+            ResourceLocation itemId = ContainerHelper.getFirstMatchingItemId(level, containerPos, wantedItem.getMatcher());
+            if (itemId == null) {
+                continue;
             }
+            
+            FoundItem foundItem = new FoundItem(containerPos, itemId);
+            villager.getBrain().setMemory(MemoryModuleTypes.FOUND_ITEM.get(), foundItem);
+
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("IsItemInStorage found item {} at {} for villager {}",
+                    itemId, containerPos, villager.getId());
+            }
+            return;
         }
 
         addToScannedList(villager, zone.getUUID(), alreadyScanned);
     }
 
-    private ResourceLocation findMatchingItemId(ServerLevel level, BlockPos containerPos, WantedItem wantedItem) {
-        return ContainerHelper.getFirstMatchingItemId(level, containerPos, wantedItem.getMatcher());
-    }
 
     private void addToScannedList(Villager villager, UUID zoneId, List<UUID> alreadyScanned) {
         List<UUID> updatedList = new ArrayList<>(alreadyScanned);

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsItemInStorage.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsItemInStorage.java
@@ -1,0 +1,143 @@
+package org.sosly.villagetale.entity.ai.sensor;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.api.capability.IVillagesCapability;
+import org.sosly.villagetale.api.data.IVillageZone;
+import org.sosly.villagetale.api.data.ZoneType;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.data.FoundItem;
+import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.data.WantedItem;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.ContainerHelper;
+
+public class IsItemInStorage extends Sensor<Villager> {
+
+    public IsItemInStorage() {
+        super(200);
+    }
+
+    @Override
+    protected void doTick(ServerLevel level, Villager villager) {
+        if (villager.getBrain().hasMemoryValue(MemoryModuleTypes.FOUND_ITEM.get())) {
+            return;
+        }
+
+        WantedItem wantedItem = villager.getBrain().getMemory(MemoryModuleTypes.WANTED_ITEM.get()).orElse(null);
+        if (wantedItem == null) {
+            return;
+        }
+
+        UUID villageId = villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null);
+        if (villageId == null) {
+            return;
+        }
+
+        IVillageZone currentStorageZone = getCurrentStorageZone(level, villager, villageId);
+        if (currentStorageZone == null) {
+            return;
+        }
+
+        List<UUID> alreadyScanned = villager.getBrain().getMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get())
+            .orElse(new ArrayList<>());
+
+        if (alreadyScanned.contains(currentStorageZone.getUUID())) {
+            return;
+        }
+
+        scanStorageZone(level, villager, currentStorageZone, wantedItem, alreadyScanned);
+    }
+
+    private IVillageZone getCurrentStorageZone(ServerLevel level, Villager villager, UUID villageId) {
+        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return null;
+        }
+
+        VillageInfo village = villagesCapability.getVillageById(villageId);
+        if (village == null) {
+            return null;
+        }
+
+        ChunkPos townHallChunk = new ChunkPos(village.getTownHallPos());
+        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
+
+        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            return null;
+        }
+
+        BlockPos villagerPos = villager.blockPosition();
+        return villageCapability.getZones()
+                .stream()
+                .filter(z -> z.getType() == ZoneType.STORAGE)
+                .filter(z -> z.containsPosition(villagerPos))
+                .findFirst().orElse(null);
+    }
+
+    private void scanStorageZone(ServerLevel level, Villager villager, IVillageZone zone, WantedItem wantedItem, List<UUID> alreadyScanned) {
+        Optional<List<BlockPos>> pois = zone.getPOIs();
+        if (pois.isEmpty()) {
+            addToScannedList(villager, zone.getUUID(), alreadyScanned);
+            return;
+        }
+
+        for (BlockPos containerPos : pois.get()) {
+            if (ContainerHelper.hasMatchingItem(level, containerPos, wantedItem.getMatcher())) {
+                ResourceLocation itemId = findMatchingItemId(level, containerPos, wantedItem);
+                if (itemId != null) {
+                    FoundItem foundItem = new FoundItem(containerPos, itemId);
+                    villager.getBrain().setMemory(MemoryModuleTypes.FOUND_ITEM.get(), foundItem);
+
+                    if (VillageTale.LOGGER.isDebugEnabled()) {
+                        VillageTale.LOGGER.debug("IsItemInStorage found item {} at {} for villager {}",
+                            itemId, containerPos, villager.getId());
+                    }
+                    return;
+                }
+            }
+        }
+
+        addToScannedList(villager, zone.getUUID(), alreadyScanned);
+    }
+
+    private ResourceLocation findMatchingItemId(ServerLevel level, BlockPos containerPos, WantedItem wantedItem) {
+        return ContainerHelper.getFirstMatchingItemId(level, containerPos, wantedItem.getMatcher());
+    }
+
+    private void addToScannedList(Villager villager, UUID zoneId, List<UUID> alreadyScanned) {
+        List<UUID> updatedList = new ArrayList<>(alreadyScanned);
+        updatedList.add(zoneId);
+        villager.getBrain().setMemory(MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get(), updatedList);
+
+        if (VillageTale.LOGGER.isDebugEnabled()) {
+            VillageTale.LOGGER.debug("IsItemInStorage added zone {} to scanned list for villager {}",
+                zoneId, villager.getId());
+        }
+    }
+
+    @Override
+    public Set<MemoryModuleType<?>> requires() {
+        return ImmutableSet.of(
+            MemoryModuleTypes.WANTED_ITEM.get(),
+            MemoryModuleTypes.ALREADY_SCANNED_STORAGES.get(),
+            MemoryModuleTypes.FOUND_ITEM.get(),
+            MemoryModuleTypes.VILLAGE.get()
+        );
+    }
+}

--- a/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
@@ -1,6 +1,8 @@
 package org.sosly.villagetale.helper;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
@@ -95,5 +97,19 @@ public class ContainerHelper {
         return false;
     }
 
+    public static ResourceLocation getFirstMatchingItemId(ServerLevel level, BlockPos containerPos, Predicate<ItemStack> itemMatcher) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return null;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack stack = container.getItem(i);
+            if (itemMatcher.test(stack)) {
+                return BuiltInRegistries.ITEM.getKey(stack.getItem());
+            }
+        }
+        return null;
+    }
 
 }


### PR DESCRIPTION
## Summary
- Adds IsItemInStorage sensor to search storage zones for wanted items
- Refactors all sensor names for consistency using Is/Has prefix pattern
- Implements event-based scanning (only scans each zone once per search)

## Changes
- Created IsItemInStorage sensor that activates when villager enters storage zone with WANTED_ITEM
- Added ContainerHelper.getFirstMatchingItemId() utility method
- Renamed sensors: HungerSensor → IsHungry, HasFoodSensor → HasFood, etc.
- Updated all sensor log messages to use new names

## Related Issues
Resolves #47

## Implementation Notes
The sensor uses event-based scanning by checking if a zone is in ALREADY_SCANNED_STORAGES before scanning. This prevents repeated scans of the same zone during a single search session.

## Breaking Changes
None - sensor registration names unchanged