### PR TITLE
Add DepositItem behavior

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/DepositItem.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/DepositItem.java
@@ -176,11 +176,11 @@ public class DepositItem extends Behavior<Villager> {
             return null;
         }
 
-        for (ResourceLocation itemId : itemsToDeposit.keySet()) {
-            ItemStack testItem = new ItemStack(BuiltInRegistries.ITEM.get(itemId));
-            
-            for (BlockPos containerPos : pois.get()) {
-                if (ContainerHelper.hasAvailableSpace(level, containerPos, testItem)) {
+        for (BlockPos containerPos : pois.get()) {
+            for (ResourceLocation itemId : itemsToDeposit.keySet()) {
+                net.minecraft.world.item.Item item = BuiltInRegistries.ITEM.get(itemId);
+                
+                if (ContainerHelper.hasAvailableSpace(level, containerPos, item)) {
                     return containerPos;
                 }
             }

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/DepositItem.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/DepositItem.java
@@ -1,0 +1,339 @@
+package org.sosly.villagetale.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.api.capability.IVillagesCapability;
+import org.sosly.villagetale.api.data.IVillageZone;
+import org.sosly.villagetale.api.data.ZoneType;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.ContainerHelper;
+
+public class DepositItem extends Behavior<Villager> {
+    private static final int BEHAVIOR_DURATION = 200;
+    private static final double INTERACTION_DISTANCE = 2.0D;
+    private static final int CLAIM_DURATION = 60;
+    private static final int SEARCH_DURATION = 20;
+
+    private BlockPos targetContainer;
+    private boolean atStorageZone;
+    private boolean containerClaimed;
+    private int searchTicks;
+    private IVillageZone claimedZone;
+
+    public DepositItem() {
+        super(ImmutableMap.of(
+            MemoryModuleTypes.ITEMS_TO_DEPOSIT.get(), MemoryStatus.VALUE_PRESENT,
+            MemoryModuleTypes.VILLAGE.get(), MemoryStatus.VALUE_PRESENT
+        ), BEHAVIOR_DURATION);
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        @SuppressWarnings("unchecked")
+        Map<ResourceLocation, Integer> itemsToDeposit = villager.getBrain()
+            .getMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get()).orElse(null);
+        
+        if (itemsToDeposit == null || itemsToDeposit.isEmpty()) {
+            return false;
+        }
+
+        UUID villageId = villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null);
+        if (villageId == null) {
+            return false;
+        }
+
+        if (!isAtStorageZone(level, villager, villageId)) {
+            return false;
+        }
+
+        this.targetContainer = findAvailableContainer(level, villager, villageId, itemsToDeposit);
+        return this.targetContainer != null;
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        this.atStorageZone = true;
+        this.containerClaimed = false;
+        this.searchTicks = 0;
+        this.claimedZone = null;
+
+        if (this.targetContainer != null) {
+            villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+                new WalkTarget(this.targetContainer, 0.5F, 1));
+
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("DepositItem started walking to {} for villager {}",
+                    this.targetContainer, villager.getId());
+            }
+        }
+    }
+
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        return this.targetContainer != null &&
+               villager.getBrain().hasMemoryValue(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get());
+    }
+
+    @Override
+    protected void tick(ServerLevel level, Villager villager, long gameTime) {
+        if (this.targetContainer == null) {
+            return;
+        }
+
+        if (!villager.blockPosition().closerThan(this.targetContainer, INTERACTION_DISTANCE)) {
+            return;
+        }
+
+        if (!this.containerClaimed) {
+            handleArrival(level, villager, gameTime);
+            return;
+        }
+
+        this.searchTicks++;
+
+        if (this.searchTicks < SEARCH_DURATION) {
+            return;
+        }
+
+        depositItems(level, villager);
+        
+        @SuppressWarnings("unchecked")
+        Map<ResourceLocation, Integer> remainingItems = villager.getBrain()
+            .getMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get()).orElse(null);
+        
+        if (remainingItems == null || remainingItems.isEmpty()) {
+            clearMemories(villager);
+            stopBehavior(villager);
+        } else {
+            this.targetContainer = findAvailableContainer(level, villager, 
+                villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null), 
+                remainingItems);
+            
+            if (this.targetContainer == null) {
+                stopBehavior(villager);
+            } else {
+                resetForNewContainer(villager);
+            }
+        }
+    }
+
+    private void handleArrival(ServerLevel level, Villager villager, long gameTime) {
+        this.searchTicks = 0;
+        villager.getBrain().eraseMemory(MemoryModuleType.WALK_TARGET);
+
+        if (!claimContainer(level, villager, gameTime)) {
+            stopBehavior(villager);
+            return;
+        }
+
+        ContainerHelper.openContainer(level, this.targetContainer);
+    }
+
+    @Override
+    protected void stop(ServerLevel level, Villager villager, long gameTime) {
+        releaseContainer();
+        resetState();
+    }
+
+    private boolean isAtStorageZone(ServerLevel level, Villager villager, UUID villageId) {
+        IVillageZone zone = findZoneContaining(level, villageId, villager.blockPosition());
+        return zone != null && zone.getType() == ZoneType.STORAGE;
+    }
+
+    private BlockPos findAvailableContainer(ServerLevel level, Villager villager, UUID villageId, Map<ResourceLocation, Integer> itemsToDeposit) {
+        if (villageId == null) {
+            return null;
+        }
+
+        IVillageZone zone = findZoneContaining(level, villageId, villager.blockPosition());
+        if (zone == null || zone.getType() != ZoneType.STORAGE) {
+            return null;
+        }
+
+        Optional<List<BlockPos>> pois = zone.getPOIs();
+        if (pois.isEmpty()) {
+            return null;
+        }
+
+        for (ResourceLocation itemId : itemsToDeposit.keySet()) {
+            ItemStack testItem = new ItemStack(BuiltInRegistries.ITEM.get(itemId));
+            
+            for (BlockPos containerPos : pois.get()) {
+                if (ContainerHelper.hasAvailableSpace(level, containerPos, testItem)) {
+                    return containerPos;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private boolean claimContainer(ServerLevel level, Villager villager, long gameTime) {
+        UUID villageId = villager.getBrain().getMemory(MemoryModuleTypes.VILLAGE.get()).orElse(null);
+        if (villageId == null) {
+            return false;
+        }
+
+        IVillageZone zone = findZoneContaining(level, villageId, this.targetContainer);
+        if (zone == null) {
+            return false;
+        }
+
+        boolean claimed = zone.claim(this.targetContainer, villager.getUUID(), CLAIM_DURATION, gameTime);
+        if (!claimed) {
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("DepositItem failed to claim container at {} for villager {}",
+                    this.targetContainer, villager.getId());
+            }
+            return false;
+        }
+
+        this.containerClaimed = true;
+        this.claimedZone = zone;
+
+        if (VillageTale.LOGGER.isDebugEnabled()) {
+            VillageTale.LOGGER.debug("DepositItem claimed container at {} for villager {}",
+                this.targetContainer, villager.getId());
+        }
+
+        return true;
+    }
+
+    private void depositItems(ServerLevel level, Villager villager) {
+        @SuppressWarnings("unchecked")
+        Map<ResourceLocation, Integer> itemsToDeposit = villager.getBrain()
+            .getMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get()).orElse(null);
+        
+        if (itemsToDeposit == null || itemsToDeposit.isEmpty()) {
+            return;
+        }
+
+        SimpleContainer inventory = villager.getInventory();
+        Map<ResourceLocation, Integer> updatedItems = new HashMap<>(itemsToDeposit);
+
+        for (int slot = 0; slot < inventory.getContainerSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (stack.isEmpty()) {
+                continue;
+            }
+
+            ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            Integer wantedAmount = itemsToDeposit.get(itemId);
+            if (wantedAmount == null || wantedAmount <= 0) {
+                continue;
+            }
+
+            int deposited = ContainerHelper.depositItemToContainer(level, this.targetContainer, stack, wantedAmount);
+            if (deposited <= 0) {
+                continue;
+            }
+
+            stack.shrink(deposited);
+            int remaining = wantedAmount - deposited;
+            
+            if (remaining <= 0) {
+                updatedItems.remove(itemId);
+            } else {
+                updatedItems.put(itemId, remaining);
+            }
+
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("DepositItem deposited {} x{} for villager {}",
+                    itemId, deposited, villager.getId());
+            }
+        }
+
+        if (updatedItems.isEmpty()) {
+            villager.getBrain().eraseMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get());
+        } else {
+            villager.getBrain().setMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get(), updatedItems);
+        }
+    }
+
+    private IVillageZone findZoneContaining(ServerLevel level, UUID villageId, BlockPos pos) {
+        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return null;
+        }
+
+        VillageInfo village = villagesCapability.getVillageById(villageId);
+        if (village == null) {
+            return null;
+        }
+
+        ChunkPos townHallChunk = new ChunkPos(village.getTownHallPos());
+        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
+
+        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (villageCapability == null) {
+            return null;
+        }
+
+        return villageCapability.getZones()
+                .stream()
+                .filter(zone -> {
+                    Optional<List<BlockPos>> pois = zone.getPOIs();
+                    return pois.map(list -> list.contains(pos)).orElse(false);
+                })
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void releaseContainer() {
+        if (this.containerClaimed && this.claimedZone != null && this.targetContainer != null) {
+            boolean released = this.claimedZone.release(this.targetContainer);
+
+            if (VillageTale.LOGGER.isDebugEnabled()) {
+                VillageTale.LOGGER.debug("DepositItem {} container at {}",
+                    released ? "released" : "failed to release", this.targetContainer);
+            }
+        }
+    }
+
+    private void clearMemories(Villager villager) {
+        villager.getBrain().eraseMemory(MemoryModuleTypes.ITEMS_TO_DEPOSIT.get());
+    }
+
+    private void resetState() {
+        this.targetContainer = null;
+        this.atStorageZone = false;
+        this.containerClaimed = false;
+        this.searchTicks = 0;
+        this.claimedZone = null;
+    }
+
+    private void resetForNewContainer(Villager villager) {
+        releaseContainer();
+        this.containerClaimed = false;
+        this.searchTicks = 0;
+        this.claimedZone = null;
+
+        villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+            new WalkTarget(this.targetContainer, 0.5F, 1));
+    }
+
+    private void stopBehavior(Villager villager) {
+        villager.getBrain().eraseMemory(MemoryModuleType.WALK_TARGET);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/entity/ai/goals/VillagerGoalPackages.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/goals/VillagerGoalPackages.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.ai.behavior.VillageBoundRandomStroll;
 import net.minecraft.world.entity.ai.behavior.VillagerCalmDown;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.entity.ai.behavior.DepositItem;
 import org.sosly.villagetale.entity.ai.behavior.EatFood;
 import org.sosly.villagetale.entity.ai.behavior.GetFromContainer;
 import org.sosly.villagetale.entity.ai.behavior.GoToAssignedBed;
@@ -38,6 +39,7 @@ public class VillagerGoalPackages {
             Pair.of(1, WakeUp.create()),
             Pair.of(2, (BehaviorControl<? super Villager>) new EatFood()),
             Pair.of(3, (BehaviorControl<? super Villager>) new GetFromContainer()),
+            Pair.of(3, (BehaviorControl<? super Villager>) new DepositItem()),
             Pair.of(4, (BehaviorControl<? super Villager>) new GoToNearestStorage()),
             Pair.of(99, (BehaviorControl<? super Villager>) UpdateActivityFromSchedule.create())
         );

--- a/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
@@ -112,4 +112,70 @@ public class ContainerHelper {
         return null;
     }
 
+    public static int depositItemToContainer(ServerLevel level, BlockPos containerPos, ItemStack itemToDeposit, int maxAmount) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return 0;
+        }
+
+        int remainingToDeposit = Math.min(itemToDeposit.getCount(), maxAmount);
+        int deposited = 0;
+
+        for (int i = 0; i < container.getContainerSize() && remainingToDeposit > 0; i++) {
+            ItemStack existingStack = container.getItem(i);
+
+            if (existingStack.isEmpty()) {
+                int depositAmount = Math.min(remainingToDeposit, itemToDeposit.getMaxStackSize());
+                ItemStack newStack = itemToDeposit.copy();
+                newStack.setCount(depositAmount);
+                container.setItem(i, newStack);
+                deposited += depositAmount;
+                remainingToDeposit -= depositAmount;
+                continue;
+            }
+            
+            if (!ItemStack.isSameItemSameTags(existingStack, itemToDeposit)) {
+                continue;
+            }
+            
+            int spaceAvailable = existingStack.getMaxStackSize() - existingStack.getCount();
+            int depositAmount = Math.min(remainingToDeposit, spaceAvailable);
+            if (depositAmount <= 0) {
+                continue;
+            }
+            
+            existingStack.grow(depositAmount);
+            deposited += depositAmount;
+            remainingToDeposit -= depositAmount;
+        }
+
+        if (deposited > 0) {
+            container.setChanged();
+        }
+
+        return deposited;
+    }
+
+    public static boolean hasAvailableSpace(ServerLevel level, BlockPos containerPos, ItemStack itemToCheck) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return false;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack existingStack = container.getItem(i);
+
+            if (existingStack.isEmpty()) {
+                return true;
+            } else if (ItemStack.isSameItemSameTags(existingStack, itemToCheck)) {
+                int spaceAvailable = existingStack.getMaxStackSize() - existingStack.getCount();
+                if (spaceAvailable > 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
@@ -179,4 +179,26 @@ public class ContainerHelper {
         return false;
     }
 
+    public static boolean hasAvailableSpace(ServerLevel level, BlockPos containerPos, net.minecraft.world.item.Item item) {
+        BlockEntity blockEntity = level.getBlockEntity(containerPos);
+        if (!(blockEntity instanceof Container container)) {
+            return false;
+        }
+
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            ItemStack existingStack = container.getItem(i);
+
+            if (existingStack.isEmpty()) {
+                return true;
+            } else if (existingStack.is(item)) {
+                int spaceAvailable = existingStack.getMaxStackSize() - existingStack.getCount();
+                if (spaceAvailable > 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/ContainerHelper.java
@@ -125,7 +125,8 @@ public class ContainerHelper {
             ItemStack existingStack = container.getItem(i);
 
             if (existingStack.isEmpty()) {
-                int depositAmount = Math.min(remainingToDeposit, itemToDeposit.getMaxStackSize());
+                int maxStackSize = container.getMaxStackSize();
+                int depositAmount = Math.min(remainingToDeposit, Math.min(itemToDeposit.getMaxStackSize(), maxStackSize));
                 ItemStack newStack = itemToDeposit.copy();
                 newStack.setCount(depositAmount);
                 container.setItem(i, newStack);


### PR DESCRIPTION
# Add DepositItem behavior
Implements behavior for villagers to deposit items into storage containers when they have ITEMS_TO_DEPOSIT memory set.

## Changes
- Add `depositItemToContainer` and `hasAvailableSpace` methods to ContainerHelper
- Create DepositItem behavior that finds containers with available space and deposits items
- Register DepositItem behavior in VillagerGoalPackages at priority 3
- Behavior claims containers for 60 ticks during deposit operations
- Updates ITEMS_TO_DEPOSIT memory with remaining items after each deposit
- Clears memory when all items successfully deposited

## Related Issues
Resolves #54

## Implementation Notes
Follows the same pattern as GetFromContainer but reverses the operation. Only activates when villager is already at a storage zone with items to deposit. Handles partial deposits when containers become full and continues searching for additional containers.

## Breaking Changes
None