### PR TITLE
Add FARMLAND zone type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Villages & Zones**
 - Town Hall block - establish your village (automatically named after you)
 - Villages must be at least 30 chunks apart
-- Zone system for defining areas within villages (storage, homes, gathering spaces)
-- Four zone shapes available: rectangular, circular, single block, or custom path
+- Zone system for defining areas within villages
+- Four zone shapes available: rectangle, sphere, point, or route
+- Many zone types available:
+    farmland, home, storage, townhall
 
 **Commands**
 - `/vw assign` - Assign homes to villagers

--- a/src/main/java/org/sosly/villagetale/api/IZoneType.java
+++ b/src/main/java/org/sosly/villagetale/api/IZoneType.java
@@ -7,7 +7,7 @@ import net.minecraft.world.level.Level;
 
 public interface IZoneType {
     ResourceLocation getID();
-    boolean isPoI(Level level, BlockPos pos);
+    boolean isPOI(Level level, BlockPos pos);
     CompoundTag serializeNBT();
     void deserializeNBT(CompoundTag nbt);
 }

--- a/src/main/java/org/sosly/villagetale/data/TagKeys.java
+++ b/src/main/java/org/sosly/villagetale/data/TagKeys.java
@@ -6,6 +6,7 @@ import net.minecraft.world.level.block.Block;
 import org.sosly.villagetale.VillageTale;
 
 public class TagKeys {
+    public static final TagKey<Block> FARMABLE = create("farmable");
     public static final TagKey<Block> STORAGE_CONTAINERS = create("storage_containers");
 
     private static TagKey<Block> create(String name) {

--- a/src/main/java/org/sosly/villagetale/zone/Types.java
+++ b/src/main/java/org/sosly/villagetale/zone/Types.java
@@ -2,6 +2,7 @@ package org.sosly.villagetale.zone;
 
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.sosly.villagetale.event.RegisterZoneTypesEvent;
+import org.sosly.villagetale.zone.type.Farmland;
 import org.sosly.villagetale.zone.type.Home;
 import org.sosly.villagetale.zone.type.Storage;
 import org.sosly.villagetale.zone.type.TownHall;
@@ -10,6 +11,7 @@ import org.sosly.villagetale.zone.type.TownHall;
 public class Types {
     @SubscribeEvent
     public static void onRegisterZoneTypes(RegisterZoneTypesEvent event) {
+        event.register(Farmland.ID, Farmland::new);
         event.register(Home.ID, Home::new);
         event.register(Storage.ID, Storage::new);
         event.register(TownHall.ID, TownHall::new);

--- a/src/main/java/org/sosly/villagetale/zone/Zone.java
+++ b/src/main/java/org/sosly/villagetale/zone/Zone.java
@@ -237,7 +237,7 @@ public class Zone implements IVillageZone {
 
     private Optional<List<BlockPos>> getPOIs() {
         return Optional.ofNullable(this.shape.getPOIs(this.village.getChunk().getLevel(),
-                (pos) -> this.type.isPoI(this.village.getChunk().getLevel(), pos)));
+                (pos) -> this.type.isPOI(this.village.getChunk().getLevel(), pos)));
     }
 
     private void markDirty() {

--- a/src/main/java/org/sosly/villagetale/zone/ZoneRegistry.java
+++ b/src/main/java/org/sosly/villagetale/zone/ZoneRegistry.java
@@ -11,6 +11,7 @@ import org.sosly.villagetale.zone.shape.Point;
 import org.sosly.villagetale.zone.shape.Rectangle;
 import org.sosly.villagetale.zone.shape.Route;
 import org.sosly.villagetale.zone.shape.Sphere;
+import org.sosly.villagetale.zone.type.Farmland;
 import org.sosly.villagetale.zone.type.Home;
 import org.sosly.villagetale.zone.type.Storage;
 import org.sosly.villagetale.zone.type.TownHall;
@@ -46,6 +47,7 @@ public class ZoneRegistry {
 
     {
         // todo: this is a hack because the events are not working for some reason.
+        TYPES.put(Farmland.ID, Farmland::new);
         TYPES.put(Home.ID, Home::new);
         TYPES.put(Storage.ID, Storage::new);
         TYPES.put(TownHall.ID, TownHall::new);

--- a/src/main/java/org/sosly/villagetale/zone/type/Farmland.java
+++ b/src/main/java/org/sosly/villagetale/zone/type/Farmland.java
@@ -3,14 +3,15 @@ package org.sosly.villagetale.zone.type;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IZoneType;
 import org.sosly.villagetale.data.TagKeys;
 
-public class Storage implements IZoneType {
-    public static final ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "storage");
+public class Farmland implements IZoneType {
+    public static final ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "farmland");
 
     @Override
     public ResourceLocation getID() {
@@ -20,7 +21,17 @@ public class Storage implements IZoneType {
     @Override
     public boolean isPOI(Level level, BlockPos pos) {
         BlockState state = level.getBlockState(pos);
-        return state.is(TagKeys.STORAGE_CONTAINERS);
+        BlockState above = level.getBlockState(pos.above());
+
+        if (!above.isAir()) {
+            return false;
+        }
+
+        if (!state.is(TagKeys.FARMABLE) && !state.is(BlockTags.MAINTAINS_FARMLAND)) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/zone/type/Home.java
+++ b/src/main/java/org/sosly/villagetale/zone/type/Home.java
@@ -18,7 +18,7 @@ public class Home implements IZoneType {
     }
 
     @Override
-    public boolean isPoI(Level level, BlockPos pos) {
+    public boolean isPOI(Level level, BlockPos pos) {
         BlockState state = level.getBlockState(pos);
         return state.is(BlockTags.BEDS);
     }

--- a/src/main/java/org/sosly/villagetale/zone/type/TownHall.java
+++ b/src/main/java/org/sosly/villagetale/zone/type/TownHall.java
@@ -18,7 +18,7 @@ public class TownHall implements IZoneType {
     }
 
     @Override
-    public boolean isPoI(Level level, BlockPos pos) {
+    public boolean isPOI(Level level, BlockPos pos) {
         BlockState state = level.getBlockState(pos);
         return state.is(BlockTypes.TOWNHALL.get());
     }

--- a/src/main/resources/data/villagetale/tags/blocks/farmable.json
+++ b/src/main/resources/data/villagetale/tags/blocks/farmable.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:dirt",
+    "minecraft:grass_block",
+    "minecraft:farmland"
+  ]
+}


### PR DESCRIPTION
# Add FARMLAND zone type
Implements a new zone type for designating farming areas where farmer villagers will work.

## Changes
- Added Farmland zone type class implementing IZoneType
- Registered FARMLAND in ZoneRegistry and Types enum
- Created farmable blocks tag for defining valid farming blocks
- Updated zone system to support zones without POIs

## Related Issues
Resolves #40

## Implementation Notes
FARMLAND zones differ from other zone types by not requiring POIs - all farmable blocks within the zone boundaries are considered workable. The farmable blocks tag allows server configuration of what blocks can be farmed.

## Breaking Changes
None