### PR TITLE
Create farming memory modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 **Villagers**
-- New custom Villager entity with hunger system
-- Villagers automatically eat food when hungry
-- Villagers can identify and use storage containers (customizable via datapack tags)
+- New custom Villager entity
+- Villager profession system with many professions available:
+    Commoner (unemployed), Farmer
 
 **Villages & Zones**
 - Town Hall block - establish your village (automatically named after you)

--- a/src/main/java/org/sosly/villagetale/api/serialization/Codecs.java
+++ b/src/main/java/org/sosly/villagetale/api/serialization/Codecs.java
@@ -1,0 +1,23 @@
+package org.sosly.villagetale.api.serialization;
+
+import com.mojang.serialization.Codec;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class Codecs {
+    public static Codec<java.util.UUID> UUID = Codec.BYTE_BUFFER.xmap(
+        buffer -> {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            ByteBuffer bb = ByteBuffer.wrap(bytes);
+            return new UUID(bb.getLong(), bb.getLong());
+        },
+        uuid -> {
+            ByteBuffer buffer = ByteBuffer.allocate(16);
+            buffer.putLong(uuid.getMostSignificantBits());
+            buffer.putLong(uuid.getLeastSignificantBits());
+            buffer.flip();
+            return buffer;
+        }
+    );
+}

--- a/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
@@ -1,13 +1,10 @@
 package org.sosly.villagetale.entity;
 
 import com.mojang.serialization.Codec;
-import java.nio.ByteBuffer;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import net.minecraft.world.item.ItemStack;
+import java.util.Optional;
+import java.util.UUID;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -17,13 +14,21 @@ import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.data.FoundItem;
 import org.sosly.villagetale.data.WantedItem;
+import org.sosly.villagetale.api.serialization.Codecs;
 
 public class MemoryModuleTypes {
     public static final DeferredRegister<MemoryModuleType<?>> MEMORY_MODULE_TYPES =
         DeferredRegister.create(ForgeRegistries.MEMORY_MODULE_TYPES, VillageTale.MOD_ID);
 
+
+    public static final RegistryObject<MemoryModuleType<List<UUID>>> ALREADY_SCANNED_STORAGES =
+        MEMORY_MODULE_TYPES.register("already_scanned_storages", () -> new MemoryModuleType<>(Optional.empty()));
+
     public static final RegistryObject<MemoryModuleType<Boolean>> CAN_EAT =
         MEMORY_MODULE_TYPES.register("can_eat", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+
+    public static final RegistryObject<MemoryModuleType<FoundItem>> FOUND_ITEM =
+            MEMORY_MODULE_TYPES.register("found_item", () -> new MemoryModuleType<>(Optional.empty()));
 
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_HUNGRY =
         MEMORY_MODULE_TYPES.register("is_hungry", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
@@ -31,39 +36,19 @@ public class MemoryModuleTypes {
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_STARVING =
         MEMORY_MODULE_TYPES.register("is_starving", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
 
+    public static final RegistryObject<MemoryModuleType<Map<ResourceLocation, Integer>>> ITEMS_TO_DEPOSIT =
+            MEMORY_MODULE_TYPES.register("items_to_deposit", () -> new MemoryModuleType<>(Optional.empty()));
     public static final RegistryObject<MemoryModuleType<ResourceLocation>> PROFESSION =
         MEMORY_MODULE_TYPES.register("profession", () -> new MemoryModuleType<>(Optional.of(ResourceLocation.CODEC)));
 
     public static final RegistryObject<MemoryModuleType<UUID>> VILLAGE =
-        MEMORY_MODULE_TYPES.register("village", () -> new MemoryModuleType<>(Optional.of(
-            Codec.BYTE_BUFFER.xmap(
-                buffer -> {
-                    byte[] bytes = new byte[buffer.remaining()];
-                    buffer.get(bytes);
-                    ByteBuffer bb = ByteBuffer.wrap(bytes);
-                    return new UUID(bb.getLong(), bb.getLong());
-                },
-                uuid -> {
-                    ByteBuffer buffer = ByteBuffer.allocate(16);
-                    buffer.putLong(uuid.getMostSignificantBits());
-                    buffer.putLong(uuid.getLeastSignificantBits());
-                    buffer.flip();
-                    return buffer;
-                }
-            )
-        )));
+        MEMORY_MODULE_TYPES.register("village", () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
 
     public static final RegistryObject<MemoryModuleType<WantedItem>> WANTED_ITEM =
         MEMORY_MODULE_TYPES.register("wanted_item", () -> new MemoryModuleType<>(Optional.empty()));
 
-    public static final RegistryObject<MemoryModuleType<List<UUID>>> ALREADY_SCANNED_STORAGES =
-        MEMORY_MODULE_TYPES.register("already_scanned_storages", () -> new MemoryModuleType<>(Optional.empty()));
-
-    public static final RegistryObject<MemoryModuleType<FoundItem>> FOUND_ITEM =
-        MEMORY_MODULE_TYPES.register("found_item", () -> new MemoryModuleType<>(Optional.empty()));
-
-    public static final RegistryObject<MemoryModuleType<Map<ResourceLocation, Integer>>> ITEMS_TO_DEPOSIT =
-        MEMORY_MODULE_TYPES.register("items_to_deposit", () -> new MemoryModuleType<>(Optional.empty()));
+    public static final RegistryObject<MemoryModuleType<UUID>> WORK_ZONE =
+            MEMORY_MODULE_TYPES.register("work_zone", () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
 
     public static void register(IEventBus eventBus) {
         MEMORY_MODULE_TYPES.register(eventBus);

--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -51,7 +51,7 @@ import org.sosly.villagetale.data.LivingEntityFoodData;
 import org.sosly.villagetale.data.VillageInfo;
 import org.sosly.villagetale.entity.ai.SensorTypes;
 import org.sosly.villagetale.entity.ai.goals.VillagerGoalPackages;
-import org.sosly.villagetale.profession.Commoner;
+import org.sosly.villagetale.profession.professions.Commoner;
 import org.sosly.villagetale.profession.ProfessionRegistry;
 
 public class Villager extends PathfinderMob {

--- a/src/main/java/org/sosly/villagetale/profession/ProfessionRegistry.java
+++ b/src/main/java/org/sosly/villagetale/profession/ProfessionRegistry.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import net.minecraft.resources.ResourceLocation;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IProfession;
+import org.sosly.villagetale.profession.professions.Commoner;
 
 public class ProfessionRegistry {
     public static final ProfessionRegistry INSTANCE = new ProfessionRegistry();

--- a/src/main/java/org/sosly/villagetale/profession/Professions.java
+++ b/src/main/java/org/sosly/villagetale/profession/Professions.java
@@ -2,6 +2,7 @@ package org.sosly.villagetale.profession;
 
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.sosly.villagetale.event.RegisterProfessionsEvent;
+import org.sosly.villagetale.profession.professions.Commoner;
 
 //@Mod.EventBusSubscriber(modid = VillageTale.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class Professions {

--- a/src/main/java/org/sosly/villagetale/profession/professions/Commoner.java
+++ b/src/main/java/org/sosly/villagetale/profession/professions/Commoner.java
@@ -1,4 +1,4 @@
-package org.sosly.villagetale.profession;
+package org.sosly.villagetale.profession.professions;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
@@ -13,6 +13,7 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.IWantedItem;
 import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.profession.AbstractProfession;
 
 public class Commoner extends AbstractProfession {
     public final static ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "commoner");

--- a/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
+++ b/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
@@ -1,0 +1,80 @@
+package org.sosly.villagetale.profession.professions;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.datafixers.util.Pair;
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.RegistryObject;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.IWantedItem;
+import org.sosly.villagetale.data.WantedItem;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.profession.AbstractProfession;
+import org.sosly.villagetale.zone.type.Farmland;
+
+public class Farmer extends AbstractProfession {
+    public final static ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "farmer");
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_TILLABLE_SOIL =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_tillable_soil",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_EMPTY_FARMLAND =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_empty_farmland",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_HARVESTABLE_CROP =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_harvestable_crop",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+
+    public Farmer() {
+        super(ID);
+    }
+    @Override
+    public Optional<IWantedItem> getAlwaysWantedItems() {
+        return Optional.of(new WantedItem((ItemStack stack) -> stack
+                .is(ItemTags.VILLAGER_PLANTABLE_SEEDS), 16, 0));
+    }
+
+    @Override
+    public Optional<IWantedItem> getTool() {
+        return Optional.of(new WantedItem((ItemStack stack) -> stack
+                .is(ItemTags.HOES), 1, 1));
+    }
+
+    @Override
+    public ImmutableList<MemoryModuleType<?>> getMemoryModules() {
+        return ImmutableList.of(
+            Farmer.NEAREST_TILLABLE_SOIL.get(),
+            Farmer.NEAREST_EMPTY_FARMLAND.get(),
+            Farmer.NEAREST_HARVESTABLE_CROP.get(),
+            MemoryModuleTypes.WORK_ZONE.get()
+        );
+    }
+
+    @Override
+    public ImmutableList<SensorType<? extends Sensor<? super Villager>>> getSensors() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public ImmutableList<? extends Pair<Integer, ? extends BehaviorControl<? super Villager>>> getWorkPackage(float speedModifier) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public void registerAdditionalGoals(Brain<Villager> brain) {
+    }
+
+    @Override
+    public boolean isValidWorkZone(IVillageZone zone) {
+        return zone.getType().getID().equals(Farmland.ID);
+    }
+}


### PR DESCRIPTION
# Create farming memory modules
Implements memory modules for tracking farmland states and work zones for farmer villagers.

## Changes
- Added WORK_ZONE memory module for persistent zone assignment
- Added NEAREST_TILLABLE_SOIL memory module for dirt/grass tracking
- Added NEAREST_EMPTY_FARMLAND memory module for planting locations
- Added NEAREST_HARVESTABLE_CROP memory module for harvest targets
- Created UUID codec for serializing work zone references
- Reorganized profession classes into subpackage

## Related Issues
Resolves #50

## Implementation Notes
BlockPos memories are configured with 200-400 tick expiration times to balance performance with accuracy. WORK_ZONE uses UUID to reference zones and has no expiration for persistent assignment. Memory modules are registered but only assigned to farmer profession villagers.

## Breaking Changes
None