### PR TITLE
Create GoToWorkZone behavior

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -20,35 +21,57 @@ public class MemoryModuleTypes {
     public static final DeferredRegister<MemoryModuleType<?>> MEMORY_MODULE_TYPES =
         DeferredRegister.create(ForgeRegistries.MEMORY_MODULE_TYPES, VillageTale.MOD_ID);
 
-
+    // Shared Memories
     public static final RegistryObject<MemoryModuleType<List<UUID>>> ALREADY_SCANNED_STORAGES =
-        MEMORY_MODULE_TYPES.register("already_scanned_storages", () -> new MemoryModuleType<>(Optional.empty()));
+        MEMORY_MODULE_TYPES.register("already_scanned_storages",
+                () -> new MemoryModuleType<>(Optional.empty()));
 
     public static final RegistryObject<MemoryModuleType<Boolean>> CAN_EAT =
-        MEMORY_MODULE_TYPES.register("can_eat", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+        MEMORY_MODULE_TYPES.register("can_eat",
+                () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
 
     public static final RegistryObject<MemoryModuleType<FoundItem>> FOUND_ITEM =
-            MEMORY_MODULE_TYPES.register("found_item", () -> new MemoryModuleType<>(Optional.empty()));
+            MEMORY_MODULE_TYPES.register("found_item",
+                    () -> new MemoryModuleType<>(Optional.empty()));
 
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_HUNGRY =
-        MEMORY_MODULE_TYPES.register("is_hungry", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+        MEMORY_MODULE_TYPES.register("is_hungry",
+                () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
 
     public static final RegistryObject<MemoryModuleType<Boolean>> IS_STARVING =
-        MEMORY_MODULE_TYPES.register("is_starving", () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
+        MEMORY_MODULE_TYPES.register("is_starving",
+                () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));
 
     public static final RegistryObject<MemoryModuleType<Map<ResourceLocation, Integer>>> ITEMS_TO_DEPOSIT =
-            MEMORY_MODULE_TYPES.register("items_to_deposit", () -> new MemoryModuleType<>(Optional.empty()));
+            MEMORY_MODULE_TYPES.register("items_to_deposit",
+                    () -> new MemoryModuleType<>(Optional.empty()));
     public static final RegistryObject<MemoryModuleType<ResourceLocation>> PROFESSION =
-        MEMORY_MODULE_TYPES.register("profession", () -> new MemoryModuleType<>(Optional.of(ResourceLocation.CODEC)));
+        MEMORY_MODULE_TYPES.register("profession",
+                () -> new MemoryModuleType<>(Optional.of(ResourceLocation.CODEC)));
 
     public static final RegistryObject<MemoryModuleType<UUID>> VILLAGE =
-        MEMORY_MODULE_TYPES.register("village", () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
+        MEMORY_MODULE_TYPES.register("village",
+                () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
 
     public static final RegistryObject<MemoryModuleType<WantedItem>> WANTED_ITEM =
-        MEMORY_MODULE_TYPES.register("wanted_item", () -> new MemoryModuleType<>(Optional.empty()));
+        MEMORY_MODULE_TYPES.register("wanted_item",
+                () -> new MemoryModuleType<>(Optional.empty()));
 
     public static final RegistryObject<MemoryModuleType<UUID>> WORK_ZONE =
-            MEMORY_MODULE_TYPES.register("work_zone", () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
+            MEMORY_MODULE_TYPES.register("work_zone",
+                    () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
+
+    // Farmer Memories
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_TILLABLE_SOIL =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_tillable_soil",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_EMPTY_FARMLAND =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_empty_farmland",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_HARVESTABLE_CROP =
+            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_harvestable_crop",
+                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
+
 
     public static void register(IEventBus eventBus) {
         MEMORY_MODULE_TYPES.register(eventBus);

--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -293,6 +293,7 @@ public class Villager extends PathfinderMob {
         if (!(this.level() instanceof ServerLevel serverLevel)) {
             return;
         }
+
         this.refreshBrain(serverLevel);
     }
 
@@ -454,11 +455,11 @@ public class Villager extends PathfinderMob {
                 SensorType.NEAREST_PLAYERS,
                 SensorType.HURT_BY,
                 SensorType.VILLAGER_HOSTILES,
-                SensorTypes.HUNGER.get(),
+                SensorTypes.IS_HUNGRY.get(),
                 SensorTypes.HAS_FOOD.get(),
                 SensorTypes.HAS_TOOL.get(),
                 SensorTypes.HAS_RESOURCE.get(),
-                SensorTypes.SEARCH_STORAGE_FOR_ITEM.get(),
+                SensorTypes.IS_ITEM_IN_STORAGE.get(),
                 SensorTypes.HAS_ITEMS_TO_DEPOSIT.get()
             );
         }

--- a/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
@@ -10,6 +10,7 @@ import org.sosly.villagetale.entity.ai.sensor.HasFood;
 import org.sosly.villagetale.entity.ai.sensor.HasItemsToDeposit;
 import org.sosly.villagetale.entity.ai.sensor.HasResources;
 import org.sosly.villagetale.entity.ai.sensor.HasTool;
+import org.sosly.villagetale.entity.ai.sensor.HasWorkZone;
 import org.sosly.villagetale.entity.ai.sensor.IsHungry;
 import org.sosly.villagetale.entity.ai.sensor.IsItemInStorage;
 
@@ -17,23 +18,27 @@ public class SensorTypes {
     public static final DeferredRegister<SensorType<?>> SENSOR_TYPES =
         DeferredRegister.create(ForgeRegistries.SENSOR_TYPES, VillageTale.MOD_ID);
 
-    public static final RegistryObject<SensorType<IsHungry>> HUNGER =
-        SENSOR_TYPES.register("hunger", () -> new SensorType<>(IsHungry::new));
-
     public static final RegistryObject<SensorType<HasFood>> HAS_FOOD =
         SENSOR_TYPES.register("has_food", () -> new SensorType<>(HasFood::new));
 
-    public static final RegistryObject<SensorType<HasTool>> HAS_TOOL =
-        SENSOR_TYPES.register("has_tool", () -> new SensorType<>(HasTool::new));
+    public static final RegistryObject<SensorType<HasItemsToDeposit>> HAS_ITEMS_TO_DEPOSIT =
+            SENSOR_TYPES.register("has_items_to_deposit", () -> new SensorType<>(HasItemsToDeposit::new));
 
     public static final RegistryObject<SensorType<HasResources>> HAS_RESOURCE =
         SENSOR_TYPES.register("has_resource", () -> new SensorType<>(HasResources::new));
 
-    public static final RegistryObject<SensorType<IsItemInStorage>> SEARCH_STORAGE_FOR_ITEM =
-        SENSOR_TYPES.register("search_storage_for_item", () -> new SensorType<>(IsItemInStorage::new));
+    public static final RegistryObject<SensorType<HasTool>> HAS_TOOL =
+            SENSOR_TYPES.register("has_tool", () -> new SensorType<>(HasTool::new));
 
-    public static final RegistryObject<SensorType<HasItemsToDeposit>> HAS_ITEMS_TO_DEPOSIT =
-        SENSOR_TYPES.register("has_items_to_deposit", () -> new SensorType<>(HasItemsToDeposit::new));
+    public static final RegistryObject<SensorType<HasWorkZone>> HAS_WORK_ZONE =
+            SENSOR_TYPES.register("has_work_zone", () -> new SensorType<>(HasWorkZone::new));
+
+    public static final RegistryObject<SensorType<IsHungry>> IS_HUNGRY =
+            SENSOR_TYPES.register("is_hungry", () -> new SensorType<>(IsHungry::new));
+
+    public static final RegistryObject<SensorType<IsItemInStorage>> IS_ITEM_IN_STORAGE =
+            SENSOR_TYPES.register("is_item_in_storage", () -> new SensorType<>(IsItemInStorage::new));
+
 
     public static void register(IEventBus eventBus) {
         SENSOR_TYPES.register(eventBus);

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorage.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorage.java
@@ -11,17 +11,13 @@ import net.minecraft.world.entity.ai.behavior.Behavior;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
-import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.LevelChunk;
 import org.sosly.villagetale.VillageTale;
-import org.sosly.villagetale.api.capability.IVillageCapability;
-import org.sosly.villagetale.api.capability.IVillagesCapability;
 import org.sosly.villagetale.api.IVillageZone;
-import org.sosly.villagetale.zone.type.Storage;
-import org.sosly.villagetale.capability.Capabilities;
-import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.VillagesHelper;
+import org.sosly.villagetale.zone.type.Storage;
 
 public class GoToNearestStorage extends Behavior<Villager> {
     private static final int BEHAVIOR_DURATION = 200;
@@ -95,38 +91,13 @@ public class GoToNearestStorage extends Behavior<Villager> {
             return false;
         }
 
-        boolean closeEnough = villager.blockPosition().closerThan(this.targetStoragePos, ARRIVAL_DISTANCE);
-        if (closeEnough) {
-            if (VillageTale.LOGGER.isDebugEnabled()) {
-                VillageTale.LOGGER.debug("GoToNearestStorage stopping - villager {} arrived at storage {}",
-                    villager.getId(), this.targetStoragePos);
-            }
-            return false;
-        }
-
-        return true;
+        return villager.blockPosition().closerThan(this.targetStoragePos, ARRIVAL_DISTANCE);
     }
 
     private BlockPos findNearestStorage(ServerLevel level, Villager villager, UUID villageId, boolean excludeScanned) {
-        IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
-        if (villagesCapability == null) {
-            return null;
-        }
+        IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
 
-        VillageInfo village = villagesCapability.getVillageById(villageId);
-        if (village == null) {
-            return null;
-        }
-
-        ChunkPos townHallChunk = new ChunkPos(village.getTownHallPos());
-        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
-
-        IVillageCapability villageCapability = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
-        if (villageCapability == null) {
-            return null;
-        }
-
-        List<IVillageZone> zones = villageCapability.getZones();
+        List<IVillageZone> zones = village.getZones();
         BlockPos villagerPos = villager.blockPosition();
         BlockPos nearestZoneCenter = null;
         double nearestDistance = Double.MAX_VALUE;

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorage.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToNearestStorage.java
@@ -91,11 +91,15 @@ public class GoToNearestStorage extends Behavior<Villager> {
             return false;
         }
 
-        return villager.blockPosition().closerThan(this.targetStoragePos, ARRIVAL_DISTANCE);
+        return !villager.blockPosition()
+                .closerThan(this.targetStoragePos, ARRIVAL_DISTANCE);
     }
 
     private BlockPos findNearestStorage(ServerLevel level, Villager villager, UUID villageId, boolean excludeScanned) {
         IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
+        if (village == null) {
+            return null;
+        }
 
         List<IVillageZone> zones = village.getZones();
         BlockPos villagerPos = villager.blockPosition();

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
@@ -75,11 +75,16 @@ public class GoToWorkZone extends Behavior<Villager> {
             return false;
         }
 
-        return villager.blockPosition().closerThan(zone.getStartPosition().atY(villager.getBlockY()), ARRIVAL_DISTANCE);
+        return !villager.blockPosition()
+                .closerThan(zone.getStartPosition().atY(villager.getBlockY()), ARRIVAL_DISTANCE);
     }
 
     private IVillageZone getWorkZone(ServerLevel level, Villager villager, UUID villageId, UUID workplaceId) {
         IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
+        if (village == null) {
+            return null;
+        }
+
         return village.getZones().stream()
                 .filter(z -> z.getUUID().equals(workplaceId))
                 .findFirst()

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
@@ -1,0 +1,88 @@
+package org.sosly.villagetale.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.UUID;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.VillagesHelper;
+
+public class GoToWorkZone extends Behavior<Villager> {
+    private static final int BEHAVIOR_DURATION = 200;
+    private static final double ARRIVAL_DISTANCE = 4.0;
+
+    public GoToWorkZone() {
+        super(ImmutableMap.of(
+                MemoryModuleTypes.VILLAGE.get(), MemoryStatus.VALUE_PRESENT,
+                MemoryModuleTypes.WORK_ZONE.get(), MemoryStatus.VALUE_PRESENT,
+                MemoryModuleType.WALK_TARGET, MemoryStatus.VALUE_ABSENT
+        ), BEHAVIOR_DURATION);
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        UUID villageId = villager.getVillage().get();
+        UUID workplaceId = villager.getBrain().getMemory(MemoryModuleTypes.WORK_ZONE.get()).orElse(null);
+        if (workplaceId == null) {
+            return false;
+        }
+
+        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+        if (zone == null) {
+            return false;
+        }
+
+        return !zone.containsPosition(villager.blockPosition());
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        UUID villageId = villager.getVillage().get();
+        UUID workplaceId = villager.getBrain().getMemory(MemoryModuleTypes.WORK_ZONE.get()).orElse(null);
+        if (workplaceId == null) {
+            return;
+        }
+
+        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+
+        if (zone == null) {
+            VillageTale.LOGGER.warn("No zone found for workplace " + workplaceId);
+            return;
+        }
+
+        VillageTale.LOGGER.info(String.format("Going to work zone %s", workplaceId));
+        villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+            new WalkTarget(zone.getStartPosition(), 0.5F, 2));
+    }
+
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        UUID villageId = villager.getVillage().get();
+        UUID workplaceId = villager.getBrain().getMemory(MemoryModuleTypes.WORK_ZONE.get()).orElse(null);
+        if (workplaceId == null) {
+            return false;
+        }
+
+        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+        if (zone == null) {
+            return false;
+        }
+
+        return villager.blockPosition().closerThan(zone.getStartPosition().atY(villager.getBlockY()), ARRIVAL_DISTANCE);
+    }
+
+    private IVillageZone getWorkZone(ServerLevel level, Villager villager, UUID villageId, UUID workplaceId) {
+        IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
+        return village.getZones().stream()
+                .filter(z -> z.getUUID().equals(workplaceId))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasWorkZone.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasWorkZone.java
@@ -34,6 +34,10 @@ public class HasWorkZone extends Sensor<Villager> {
         }
 
         IVillageCapability village = VillagesHelper.getVillageCapability(level, villager.getVillage().get());
+        if (village == null) {
+            return;
+        }
+
         Optional<IVillageZone> zone = village.getZones()
             .stream()
             .filter(z -> z.getAssignedVillagers().contains(villager.getUUID()))

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasWorkZone.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasWorkZone.java
@@ -1,0 +1,60 @@
+package org.sosly.villagetale.entity.ai.sensor;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import java.util.Set;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.VillagesHelper;
+import org.sosly.villagetale.profession.professions.Commoner;
+
+public class HasWorkZone extends Sensor<Villager> {
+    public HasWorkZone() {
+        super(200);
+    }
+
+    @Override
+    protected void doTick(ServerLevel level, Villager villager) {
+        if (villager.getVillage().isEmpty()) {
+            return;
+        }
+
+        if (villager.getBrain().hasMemoryValue(MemoryModuleTypes.WORK_ZONE.get())) {
+            return;
+        }
+
+        if (villager.getProfession().getID().equals(Commoner.ID)) {
+            return;
+        }
+
+        IVillageCapability village = VillagesHelper.getVillageCapability(level, villager.getVillage().get());
+        Optional<IVillageZone> zone = village.getZones()
+            .stream()
+            .filter(z -> z.getAssignedVillagers().contains(villager.getUUID()))
+            .filter(z -> villager.getProfession().isValidWorkZone(z))
+            .findFirst();
+
+        if (zone.isEmpty()) {
+            return;
+        }
+
+        villager.getBrain().setMemoryWithExpiry(MemoryModuleTypes.WORK_ZONE.get(), zone.get().getUUID(), 200);
+
+        if (VillageTale.LOGGER.isDebugEnabled()) {
+            VillageTale.LOGGER.debug("HasWorkZone: " + villager );
+        }
+    }
+
+    @Override
+    public Set<MemoryModuleType<?>> requires() {
+        return ImmutableSet.of(
+            MemoryModuleTypes.WORK_ZONE.get()
+        );
+    }
+}

--- a/src/main/java/org/sosly/villagetale/helper/VillagesHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/VillagesHelper.java
@@ -1,0 +1,33 @@
+package org.sosly.villagetale.helper;
+
+import java.util.UUID;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.api.capability.IVillagesCapability;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.data.VillageInfo;
+
+public class VillagesHelper {
+    public static IVillageCapability getVillageCapability(ServerLevel level, UUID uuid) {
+        IVillagesCapability villages = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villages == null) {
+            return null;
+        }
+
+        VillageInfo info = villages.getVillageById(uuid);
+        if (info == null) {
+            return null;
+        }
+
+        ChunkPos townHallChunk = new ChunkPos(info.getTownHallPos());
+        LevelChunk chunk = level.getChunk(townHallChunk.x, townHallChunk.z);
+
+        IVillageCapability village = chunk.getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+        if (village == null) {
+            return null;
+        }
+        return village;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/profession/AbstractProfession.java
+++ b/src/main/java/org/sosly/villagetale/profession/AbstractProfession.java
@@ -1,10 +1,12 @@
 package org.sosly.villagetale.profession;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.schedule.Schedule;
 import net.minecraft.world.entity.schedule.ScheduleBuilder;
 import org.sosly.villagetale.api.IProfession;
+import org.sosly.villagetale.entity.Villager;
 
 public abstract class AbstractProfession implements IProfession {
     private final ResourceLocation id;
@@ -31,5 +33,9 @@ public abstract class AbstractProfession implements IProfession {
             .changeActivityAt(11000, Activity.IDLE)   // IDLE  (5 PM - 8 PM, evening social)
             .changeActivityAt(14000, Activity.REST)   // REST  (8 PM - 6 AM, sleep)
             .build();
+    }
+
+    @Override
+    public void registerAdditionalGoals(Brain<Villager> brain) {
     }
 }

--- a/src/main/java/org/sosly/villagetale/profession/ProfessionRegistry.java
+++ b/src/main/java/org/sosly/villagetale/profession/ProfessionRegistry.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IProfession;
 import org.sosly.villagetale.profession.professions.Commoner;
+import org.sosly.villagetale.profession.professions.Farmer;
 
 public class ProfessionRegistry {
     public static final ProfessionRegistry INSTANCE = new ProfessionRegistry();
@@ -38,5 +39,6 @@ public class ProfessionRegistry {
 
     {
         professions.put(Commoner.ID, new Commoner());
+        professions.put(Farmer.ID, new Farmer());
     }
 }

--- a/src/main/java/org/sosly/villagetale/profession/professions/Commoner.java
+++ b/src/main/java/org/sosly/villagetale/profession/professions/Commoner.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
 import java.util.Optional;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.behavior.BehaviorControl;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
@@ -44,10 +43,6 @@ public class Commoner extends AbstractProfession {
     @Override
     public ImmutableList<? extends Pair<Integer, ? extends BehaviorControl<? super Villager>>> getWorkPackage(float speedModifier) {
         return ImmutableList.of();
-    }
-
-    @Override
-    public void registerAdditionalGoals(Brain<Villager> brain) {
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
+++ b/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
@@ -3,40 +3,31 @@ package org.sosly.villagetale.profession.professions;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
 import java.util.Optional;
-import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.behavior.BehaviorControl;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.registries.RegistryObject;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.IWantedItem;
 import org.sosly.villagetale.data.WantedItem;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.entity.ai.SensorTypes;
+import org.sosly.villagetale.entity.ai.behavior.GoToWorkZone;
 import org.sosly.villagetale.profession.AbstractProfession;
 import org.sosly.villagetale.zone.type.Farmland;
 
 public class Farmer extends AbstractProfession {
     public final static ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "farmer");
-    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_TILLABLE_SOIL =
-            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_tillable_soil",
-                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
-    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_EMPTY_FARMLAND =
-            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_empty_farmland",
-                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
-    public static final RegistryObject<MemoryModuleType<BlockPos>> NEAREST_HARVESTABLE_CROP =
-            MemoryModuleTypes.MEMORY_MODULE_TYPES.register("nearest_harvestable_crop",
-                    () -> new MemoryModuleType<>(Optional.of(BlockPos.CODEC)));
 
     public Farmer() {
         super(ID);
     }
+
     @Override
     public Optional<IWantedItem> getAlwaysWantedItems() {
         return Optional.of(new WantedItem((ItemStack stack) -> stack
@@ -52,25 +43,25 @@ public class Farmer extends AbstractProfession {
     @Override
     public ImmutableList<MemoryModuleType<?>> getMemoryModules() {
         return ImmutableList.of(
-            Farmer.NEAREST_TILLABLE_SOIL.get(),
-            Farmer.NEAREST_EMPTY_FARMLAND.get(),
-            Farmer.NEAREST_HARVESTABLE_CROP.get(),
+            MemoryModuleTypes.NEAREST_TILLABLE_SOIL.get(),
+            MemoryModuleTypes.NEAREST_EMPTY_FARMLAND.get(),
+            MemoryModuleTypes.NEAREST_HARVESTABLE_CROP.get(),
             MemoryModuleTypes.WORK_ZONE.get()
         );
     }
 
     @Override
     public ImmutableList<SensorType<? extends Sensor<? super Villager>>> getSensors() {
-        return ImmutableList.of();
+        return ImmutableList.of(
+            SensorTypes.HAS_WORK_ZONE.get()
+        );
     }
 
     @Override
     public ImmutableList<? extends Pair<Integer, ? extends BehaviorControl<? super Villager>>> getWorkPackage(float speedModifier) {
-        return ImmutableList.of();
-    }
-
-    @Override
-    public void registerAdditionalGoals(Brain<Villager> brain) {
+        return ImmutableList.of(
+            Pair.of(1, (BehaviorControl<? super Villager>) new GoToWorkZone())
+        );
     }
 
     @Override


### PR DESCRIPTION
# Create GoToWorkZone behavior
Implements behavior that navigates villagers to their assigned work zone when needed.

## Changes
- Added GoToWorkZone behavior that activates when WORK_ZONE is set but villager is not in zone
- Created HasWorkZone sensor to detect WORK_ZONE memory presence
- Added VillagesHelper utility class for zone lookup operations
- Integrated GoToWorkZone into farmer's work package
- Added isValidWorkZone method to profession system for zone validation

## Related Issues
Resolves #55

## Implementation Notes
The behavior calculates optimal entry points based on zone shape - center for rectangular/circular zones, the position itself for single blocks, and first position for paths. The HasWorkZone sensor runs periodically to check for work zone assignment.

## Breaking Changes
None