### PR TITLE
Create FarmlandSensor

### DIFF
--- a/src/main/java/org/sosly/villagetale/api/IVillageZone.java
+++ b/src/main/java/org/sosly/villagetale/api/IVillageZone.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 
 /**
@@ -100,7 +100,7 @@ public interface IVillageZone {
      * @param blockFilter Optional filter to only return claims on specific block types
      * @return Map of positions to villager UUIDs for active claims only
      */
-    Map<BlockPos, UUID> getActiveClaims(long currentTime, Optional<Predicate<Block>> blockFilter);
+    Map<BlockPos, UUID> getActiveClaims(long currentTime, Optional<Predicate<BlockState>> blockFilter);
 
     /**
      * Get available (unclaimed) positions, automatically cleaning expired claims.
@@ -108,7 +108,7 @@ public interface IVillageZone {
      * @param blockFilter Optional filter to only return positions with specific block types
      * @return List of positions that can be claimed
      */
-    List<BlockPos> getAvailableClaims(long currentTime, Optional<Predicate<Block>> blockFilter);
+    List<BlockPos> getAvailableClaims(long currentTime, Optional<Predicate<BlockState>> blockFilter);
 
     /**
      * Claims a block position for a villager with specified duration.

--- a/src/main/java/org/sosly/villagetale/data/TagKeys.java
+++ b/src/main/java/org/sosly/villagetale/data/TagKeys.java
@@ -6,8 +6,9 @@ import net.minecraft.world.level.block.Block;
 import org.sosly.villagetale.VillageTale;
 
 public class TagKeys {
-    public static final TagKey<Block> FARMABLE = create("farmable");
+    public static final TagKey<Block> PLANTABLE = create("plantable");
     public static final TagKey<Block> STORAGE_CONTAINERS = create("storage_containers");
+    public static final TagKey<Block> TILLABLE = create("tillable");
 
     private static TagKey<Block> create(String name) {
         return TagKey.create(net.minecraft.core.registries.Registries.BLOCK, new ResourceLocation(VillageTale.MOD_ID, name));

--- a/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/SensorTypes.java
@@ -11,6 +11,7 @@ import org.sosly.villagetale.entity.ai.sensor.HasItemsToDeposit;
 import org.sosly.villagetale.entity.ai.sensor.HasResources;
 import org.sosly.villagetale.entity.ai.sensor.HasTool;
 import org.sosly.villagetale.entity.ai.sensor.HasWorkZone;
+import org.sosly.villagetale.entity.ai.sensor.IsFarmland;
 import org.sosly.villagetale.entity.ai.sensor.IsHungry;
 import org.sosly.villagetale.entity.ai.sensor.IsItemInStorage;
 
@@ -32,6 +33,9 @@ public class SensorTypes {
 
     public static final RegistryObject<SensorType<HasWorkZone>> HAS_WORK_ZONE =
             SENSOR_TYPES.register("has_work_zone", () -> new SensorType<>(HasWorkZone::new));
+
+    public static final RegistryObject<SensorType<IsFarmland>> IS_FARMLAND =
+            SENSOR_TYPES.register("is_farmland", () -> new SensorType<>(IsFarmland::new));
 
     public static final RegistryObject<SensorType<IsHungry>> IS_HUNGRY =
             SENSOR_TYPES.register("is_hungry", () -> new SensorType<>(IsHungry::new));

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/GoToWorkZone.java
@@ -9,7 +9,6 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IVillageZone;
-import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.helper.VillagesHelper;
@@ -34,7 +33,7 @@ public class GoToWorkZone extends Behavior<Villager> {
             return false;
         }
 
-        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+        IVillageZone zone = VillagesHelper.getWorkZone(level, villager, villageId, workplaceId);
         if (zone == null) {
             return false;
         }
@@ -50,7 +49,7 @@ public class GoToWorkZone extends Behavior<Villager> {
             return;
         }
 
-        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+        IVillageZone zone = VillagesHelper.getWorkZone(level, villager, villageId, workplaceId);
 
         if (zone == null) {
             VillageTale.LOGGER.warn("No zone found for workplace " + workplaceId);
@@ -70,24 +69,12 @@ public class GoToWorkZone extends Behavior<Villager> {
             return false;
         }
 
-        IVillageZone zone = getWorkZone(level, villager, villageId, workplaceId);
+        IVillageZone zone = VillagesHelper.getWorkZone(level, villager, villageId, workplaceId);
         if (zone == null) {
             return false;
         }
 
         return !villager.blockPosition()
                 .closerThan(zone.getStartPosition().atY(villager.getBlockY()), ARRIVAL_DISTANCE);
-    }
-
-    private IVillageZone getWorkZone(ServerLevel level, Villager villager, UUID villageId, UUID workplaceId) {
-        IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
-        if (village == null) {
-            return null;
-        }
-
-        return village.getZones().stream()
-                .filter(z -> z.getUUID().equals(workplaceId))
-                .findFirst()
-                .orElse(null);
     }
 }

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsFarmland.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/IsFarmland.java
@@ -1,0 +1,79 @@
+package org.sosly.villagetale.entity.ai.sensor;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.helper.VillagesHelper;
+import org.sosly.villagetale.zone.type.Farmland;
+
+public class IsFarmland extends Sensor<Villager> {
+    public IsFarmland() {
+        super(100);
+    }
+
+    @Override
+    protected void doTick(ServerLevel level, Villager villager) {
+        if (villager.getVillage().isEmpty()) {
+            return;
+        }
+
+        IVillageCapability village = VillagesHelper.getVillageCapability(level, villager.getVillage().get());
+        if (village == null) {
+            return;
+        }
+
+        UUID workplaceId = villager.getBrain().getMemory(MemoryModuleTypes.WORK_ZONE.get()).orElse(null);
+        if (workplaceId == null) {
+            return;
+        }
+
+        IVillageZone zone = VillagesHelper.getWorkZone(level, villager, villager.getVillage().get(), workplaceId);
+        if (zone == null) {
+            return;
+        }
+
+        if (!zone.containsPosition(villager.blockPosition())) {
+            return;
+        }
+
+        long gameTime = level.getGameTime();
+        List<BlockPos> claims = zone.getAvailableClaims(gameTime, Optional.empty());
+        Optional<BlockPos> harvestable = claims
+            .stream()
+            .filter(pos -> Farmland.isHarvestableBlock(level, pos))
+            .findAny();
+        harvestable.ifPresent(blockPos -> villager.getBrain().setMemory(MemoryModuleTypes.NEAREST_HARVESTABLE_CROP.get(), blockPos));
+
+        Optional<BlockPos> plantable = claims
+            .stream()
+            .filter(pos -> Farmland.isPlantableBlock(level, pos))
+            .findAny();
+        plantable.ifPresent(blockPos -> villager.getBrain().setMemory(MemoryModuleTypes.NEAREST_EMPTY_FARMLAND.get(), blockPos));
+
+        Optional<BlockPos> tillable = claims
+            .stream()
+            .filter(pos -> Farmland.isTillableBlock(level, pos))
+            .findAny();
+        tillable.ifPresent(blockPos -> villager.getBrain().setMemory(MemoryModuleTypes.NEAREST_TILLABLE_SOIL.get(), blockPos));
+    }
+
+    @Override
+    public Set<MemoryModuleType<?>> requires() {
+        return ImmutableSet.of(
+            MemoryModuleTypes.WORK_ZONE.get(),
+            MemoryModuleTypes.NEAREST_EMPTY_FARMLAND.get(),
+            MemoryModuleTypes.NEAREST_HARVESTABLE_CROP.get(),
+            MemoryModuleTypes.NEAREST_TILLABLE_SOIL.get()
+        );
+    }
+}

--- a/src/main/java/org/sosly/villagetale/helper/VillagesHelper.java
+++ b/src/main/java/org/sosly/villagetale/helper/VillagesHelper.java
@@ -4,10 +4,12 @@ import java.util.UUID;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.api.capability.IVillagesCapability;
 import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.entity.Villager;
 
 public class VillagesHelper {
     public static IVillageCapability getVillageCapability(ServerLevel level, UUID uuid) {
@@ -29,5 +31,17 @@ public class VillagesHelper {
             return null;
         }
         return village;
+    }
+
+    public static IVillageZone getWorkZone(ServerLevel level, Villager villager, UUID villageId, UUID workplaceId) {
+        IVillageCapability village = VillagesHelper.getVillageCapability(level, villageId);
+        if (village == null) {
+            return null;
+        }
+
+        return village.getZones().stream()
+                .filter(z -> z.getUUID().equals(workplaceId))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
+++ b/src/main/java/org/sosly/villagetale/profession/professions/Farmer.java
@@ -53,6 +53,7 @@ public class Farmer extends AbstractProfession {
     @Override
     public ImmutableList<SensorType<? extends Sensor<? super Villager>>> getSensors() {
         return ImmutableList.of(
+            SensorTypes.IS_FARMLAND.get(),
             SensorTypes.HAS_WORK_ZONE.get()
         );
     }

--- a/src/main/java/org/sosly/villagetale/zone/Zone.java
+++ b/src/main/java/org/sosly/villagetale/zone/Zone.java
@@ -13,7 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
@@ -139,22 +139,22 @@ public class Zone implements IVillageZone {
     }
 
     @Override
-    public Map<BlockPos, UUID> getActiveClaims(long currentTime, Optional<Predicate<Block>> blockFilter) {
+    public Map<BlockPos, UUID> getActiveClaims(long currentTime, Optional<Predicate<BlockState>> blockFilter) {
         return getClaims(currentTime).entrySet().stream()
                 .filter(entry -> entry.getValue().isPresent())
                 .filter(claim -> blockFilter
-                    .map(filter -> filter.test(this.level.getBlockState(claim.getKey()).getBlock()))
+                    .map(filter -> filter.test(this.level.getBlockState(claim.getKey())))
                     .orElse(true))
                 .flatMap(entry -> entry.getValue().map(uuid -> Map.entry(entry.getKey(), uuid)).stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override
-    public List<BlockPos> getAvailableClaims(long currentTime, Optional<Predicate<Block>> blockFilter) {
+    public List<BlockPos> getAvailableClaims(long currentTime, Optional<Predicate<BlockState>> blockFilter) {
         return getClaims(currentTime).entrySet().stream()
             .filter(claim -> claim.getValue().isEmpty())
             .filter(claim -> blockFilter
-                .map(filter -> filter.test(this.level.getBlockState(claim.getKey()).getBlock()))
+                .map(filter -> filter.test(this.level.getBlockState(claim.getKey())))
                 .orElse(true))
             .map(Map.Entry::getKey)
             .collect(Collectors.toList());

--- a/src/main/java/org/sosly/villagetale/zone/type/Farmland.java
+++ b/src/main/java/org/sosly/villagetale/zone/type/Farmland.java
@@ -1,14 +1,22 @@
 package org.sosly.villagetale.zone.type;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.BlockTags;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ToolActions;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IZoneType;
-import org.sosly.villagetale.data.TagKeys;
 
 public class Farmland implements IZoneType {
     public static final ResourceLocation ID = new ResourceLocation(VillageTale.MOD_ID, "farmland");
@@ -20,18 +28,7 @@ public class Farmland implements IZoneType {
 
     @Override
     public boolean isPOI(Level level, BlockPos pos) {
-        BlockState state = level.getBlockState(pos);
-        BlockState above = level.getBlockState(pos.above());
-
-        if (!above.isAir()) {
-            return false;
-        }
-
-        if (!state.is(TagKeys.FARMABLE) && !state.is(BlockTags.MAINTAINS_FARMLAND)) {
-            return false;
-        }
-
-        return true;
+        return (isHarvestableBlock(level, pos) || isPlantableBlock(level, pos) || isTillableBlock(level, pos));
     }
 
     @Override
@@ -41,5 +38,39 @@ public class Farmland implements IZoneType {
 
     @Override
     public void deserializeNBT(CompoundTag nbt) {
+    }
+
+    public static boolean isHarvestableBlock(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        if (!(state.getBlock() instanceof CropBlock)) {
+            return false;
+        }
+
+        CropBlock block = (CropBlock) state.getBlock();
+        return block.getAge(state) >= block.getMaxAge();
+    }
+
+    public static boolean isPlantableBlock(Level level, BlockPos pos) {
+        CropBlock crop = (CropBlock) Blocks.WHEAT;
+        BlockState state = crop.defaultBlockState();
+
+        return crop.canSurvive(state, level, pos);
+    }
+
+    public static boolean isTillableBlock(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        BlockState above = level.getBlockState(pos.above());
+        ItemStack hoe = new ItemStack(Items.WOODEN_HOE);
+
+        if (!above.isAir()) {
+            return false;
+        }
+
+        BlockState tilled = state.getToolModifiedState(
+                new UseOnContext(level, null, InteractionHand.MAIN_HAND, hoe,
+                        new BlockHitResult(Vec3.atCenterOf(pos), Direction.UP, pos, false)),
+                ToolActions.HOE_TILL,false);
+
+        return tilled != null;
     }
 }


### PR DESCRIPTION
# Create FarmlandSensor
Implements sensor that scans work zones for farmable blocks and updates farming memories for farmer villagers.

## Changes
- Added IsFarmland sensor that identifies tillable, plantable, and harvestable blocks
- Sensor only activates when farmer is within their assigned work zone
- Sets NEAREST_TILLABLE_SOIL, NEAREST_EMPTY_FARMLAND, and NEAREST_HARVESTABLE_CROP memories
- Added getStartPosition() to IVillageZone interface for zone navigation
- Created static helper methods in Farmland class for block type detection
- Registered sensor in SensorTypes and added to farmer profession

## Related Issues
Resolves #51

## Implementation Notes
The sensor runs every 100 ticks to balance performance with responsiveness. It uses the zone's getAvailableClaims() method to find workable blocks, ensuring farmers don't conflict over the same blocks. Static methods in the Farmland class handle the logic for determining if blocks are tillable, plantable, or harvestable.

## Breaking Changes
None