### PR TITLE
Fix zone assignment persistence across world reloads

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -179,6 +179,11 @@ public class Villager extends PathfinderMob {
         if (profession.isPresent()) {
             tag.putString("Profession", profession.get().toString());
         }
+
+        Optional<UUID> workZoneId = this.brain.getMemory(MemoryModuleTypes.WORK_ZONE.get());
+        if (workZoneId.isPresent()) {
+            tag.putString("WorkZoneId", workZoneId.get().toString());
+        }
     }
 
     @Override
@@ -211,6 +216,11 @@ public class Villager extends PathfinderMob {
             profession = ResourceLocation.tryParse(tag.getString("Profession"));
         }
         this.brain.setMemory(MemoryModuleTypes.PROFESSION.get(), profession);
+
+        if (tag.contains("WorkZoneId")) {
+            UUID workZoneId = UUID.fromString(tag.getString("WorkZoneId"));
+            this.brain.setMemory(MemoryModuleTypes.WORK_ZONE.get(), workZoneId);
+        }
 
         if (this.level() instanceof ServerLevel) {
             this.refreshBrain((ServerLevel) this.level());

--- a/src/main/java/org/sosly/villagetale/zone/Zone.java
+++ b/src/main/java/org/sosly/villagetale/zone/Zone.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
@@ -213,6 +214,16 @@ public class Zone implements IVillageZone {
             tag.put("shape_data", shapeData);
         }
 
+        if (!villagers.isEmpty()) {
+            ListTag villagersList = new ListTag();
+            for (UUID villagerUUID : villagers) {
+                CompoundTag villagerTag = new CompoundTag();
+                villagerTag.putUUID("villager", villagerUUID);
+                villagersList.add(villagerTag);
+            }
+            tag.put("villagers", villagersList);
+        }
+
         return tag;
     }
 
@@ -234,6 +245,14 @@ public class Zone implements IVillageZone {
             shape.deserializeNBT(tag.getCompound("shape_data"));
         }
         this.shape = shape;
+
+        if (tag.contains("villagers")) {
+            ListTag villagersList = tag.getList("villagers", 10);
+            for (int i = 0; i < villagersList.size(); i++) {
+                UUID villagerUUID = villagersList.getCompound(i).getUUID("villager");
+                this.villagers.add(villagerUUID);
+            }
+        }
     }
 
     private Optional<List<BlockPos>> getPOIs() {


### PR DESCRIPTION
# Fix zone assignment persistence across world reloads
Resolves the critical bug where villager zone assignments were lost when the world was saved and reloaded, breaking the farming system.

## Changes
- Added WORK_ZONE memory serialization to Villager.addAdditionalSaveData()
- Added WORK_ZONE memory deserialization to Villager.readAdditionalSaveData()
- Added villagers list serialization to Zone.serializeNBT()
- Added villagers list deserialization to Zone.deserializeNBT()

## Related Issues
Resolves #83

## Implementation Notes
The issue was that zone assignments existed only in memory during gameplay but weren't being persisted to NBT. This fix ensures bidirectional persistence - both the villager remembers which zone they're assigned to AND the zone remembers which villagers are assigned to it.

## Breaking Changes
None