### PR TITLE
Implement Ledger item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Herder (manages animals, brings them to pens)
 
 **Villages & Zones**
+- Ledger item - craftable tool for managing villages
 - Town Hall block - establish your village (automatically named after you)
+- Bell recipe added
 - Villages must be at least 30 chunks apart
 - Zone system for defining areas within villages
 - Four zone shapes available: box, cylinder, point, or route

--- a/src/main/java/org/sosly/villagetale/VillageTale.java
+++ b/src/main/java/org/sosly/villagetale/VillageTale.java
@@ -14,6 +14,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
 import org.sosly.villagetale.block.BlockTypes;
 import org.sosly.villagetale.command.VillageTaleCommand;
+import org.sosly.villagetale.item.ItemTypes;
 import org.sosly.villagetale.compat.CompatRegistry;
 import org.sosly.villagetale.config.CommonConfig;
 import org.sosly.villagetale.entity.Activities;
@@ -38,6 +39,7 @@ public class VillageTale {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         BlockTypes.register(modEventBus);
+        ItemTypes.register(modEventBus);
         EntityTypes.register(modEventBus);
         MemoryModuleTypes.register(modEventBus);
         SensorTypes.register(modEventBus);

--- a/src/main/java/org/sosly/villagetale/item/ItemTypes.java
+++ b/src/main/java/org/sosly/villagetale/item/ItemTypes.java
@@ -1,0 +1,33 @@
+package org.sosly.villagetale.item;
+
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.sosly.villagetale.VillageTale;
+
+@Mod.EventBusSubscriber(modid = VillageTale.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ItemTypes {
+    public static final DeferredRegister<Item> ITEMS =
+        DeferredRegister.create(ForgeRegistries.ITEMS, VillageTale.MOD_ID);
+
+    public static final RegistryObject<Item> LEDGER = ITEMS.register("ledger",
+        () -> new LedgerItem(new Item.Properties().stacksTo(1)));
+
+    @SubscribeEvent
+    public static void fillCreativeTabs(BuildCreativeModeTabContentsEvent event) {
+        if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
+            event.accept(new ItemStack(LEDGER.get()));
+        }
+    }
+
+    public static void register(IEventBus eventBus) {
+        ITEMS.register(eventBus);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/item/LedgerItem.java
+++ b/src/main/java/org/sosly/villagetale/item/LedgerItem.java
@@ -1,0 +1,58 @@
+package org.sosly.villagetale.item;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public class LedgerItem extends Item {
+    private static final String VILLAGE_UUID_KEY = "VillageUUID";
+
+    public LedgerItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public boolean hasCraftingRemainingItem(ItemStack stack) {
+        return true;
+    }
+
+    @Override
+    public ItemStack getCraftingRemainingItem(ItemStack stack) {
+        return stack.copy();
+    }
+
+    @Nullable
+    public static UUID getVillageUUID(ItemStack stack) {
+        if (!stack.hasTag()) {
+            return null;
+        }
+
+        CompoundTag tag = stack.getTag();
+        if (tag == null || !tag.hasUUID(VILLAGE_UUID_KEY)) {
+            return null;
+        }
+
+        return tag.getUUID(VILLAGE_UUID_KEY);
+    }
+
+    public static void setVillageUUID(ItemStack stack, @Nullable UUID villageUUID) {
+        if (villageUUID == null) {
+            if (stack.hasTag()) {
+                CompoundTag tag = stack.getTag();
+                if (tag != null) {
+                    tag.remove(VILLAGE_UUID_KEY);
+                }
+            }
+            return;
+        }
+
+        stack.getOrCreateTag().putUUID(VILLAGE_UUID_KEY, villageUUID);
+    }
+
+    public static boolean hasVillageLink(ItemStack stack) {
+        return getVillageUUID(stack) != null;
+    }
+}

--- a/src/main/resources/assets/villagetale/lang/en_us.json
+++ b/src/main/resources/assets/villagetale/lang/en_us.json
@@ -100,6 +100,7 @@
   "villagetale.zone.woodshop": "Wood Shop",
   "villagetale.zone.numbered": "%s #%d",
   "block.villagetale.townhall": "Town Hall",
+  "item.villagetale.ledger": "Ledger",
   "villagetale.village.default_name": "%s's Village",
   "villagetale.townhall.already_exists": "Cannot place Town Hall. %s already has a Town Hall at %s",
   "villagetale.townhall.too_close": "Cannot create village this close to another village (minimum 30 chunks distance required)",

--- a/src/main/resources/assets/villagetale/models/item/ledger.json
+++ b/src/main/resources/assets/villagetale/models/item/ledger.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "villagetale:item/ledger"
+  }
+}

--- a/src/main/resources/data/minecraft/recipes/bell.json
+++ b/src/main/resources/data/minecraft/recipes/bell.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "GSG",
+    "G G",
+    " I "
+  ],
+  "key": {
+    "G": {
+      "item": "minecraft:gold_ingot"
+    },
+    "S": {
+      "item": "minecraft:stick"
+    },
+    "I": {
+      "item": "minecraft:iron_ingot"
+    }
+  },
+  "result": {
+    "item": "minecraft:bell"
+  }
+}

--- a/src/main/resources/data/villagetale/recipes/ledger.json
+++ b/src/main/resources/data/villagetale/recipes/ledger.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    " C ",
+    "EBE",
+    " K "
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:compass"
+    },
+    "E": {
+      "item": "minecraft:emerald"
+    },
+    "B": {
+      "item": "minecraft:writable_book"
+    },
+    "K": {
+      "item": "minecraft:clock"
+    }
+  },
+  "result": {
+    "item": "villagetale:ledger"
+  }
+}

--- a/src/main/resources/data/villagetale/recipes/townhall.json
+++ b/src/main/resources/data/villagetale/recipes/townhall.json
@@ -7,6 +7,9 @@
     },
     {
       "item": "minecraft:bell"
+    },
+    {
+      "item": "villagetale:ledger"
     }
   ],
   "result": {


### PR DESCRIPTION
# Implement Ledger item
Adds the Ledger item that will serve as the primary interface for village management, with NBT storage for village linking.

## Changes
- Created ItemTypes registry for standalone items
- Implemented LedgerItem with village UUID storage via NBT
- Added crafting recipe (cross pattern: compass, clock, 2 emeralds, writable book)
- Ledger returns itself when used in crafting recipes
- Updated Town Hall recipe to require ledger (ledger is returned)
- Added craftable bell recipe (4 gold, 1 stick, 1 iron)
- Added item model and translations

## Related Issues
Resolves #103

## Implementation Notes
The Ledger uses `hasCraftingRemainingItem()` and `getCraftingRemainingItem()` to return itself after crafting, similar to how milk buckets work. This allows it to be used in the Town Hall recipe without being consumed.

Interaction handlers (right-click villagers, Town Hall, air) will be implemented in separate issues as noted in the original issue.

## Breaking Changes
Town Hall recipe now requires a ledger in addition to lectern and bell.