### PR TITLE
Add villager conversion system

### DIFF
--- a/src/main/java/org/sosly/villagetale/api/IZoneShape.java
+++ b/src/main/java/org/sosly/villagetale/api/IZoneShape.java
@@ -7,7 +7,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 
 public interface IZoneShape {
     boolean containsPosition(BlockPos pos);
@@ -26,5 +26,5 @@ public interface IZoneShape {
 
     void deserializeNBT(CompoundTag nbt);
 
-    ZoneBoundaryPacket createBoundaryPacket(UUID zoneId, UUID villageId);
+    ZoneBoundary createBoundaryPacket(UUID zoneId, UUID villageId);
 }

--- a/src/main/java/org/sosly/villagetale/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villagetale/block/TownHallBlock.java
@@ -35,7 +35,7 @@ import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.VillageInfo;
 import org.sosly.villagetale.item.LedgerItem;
 import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.clientbound.OpenTownHallScreenPacket;
+import org.sosly.villagetale.network.packets.clientbound.OpenTownHallScreen;
 import org.sosly.villagetale.zone.type.TownHall;
 
 public class TownHallBlock extends Block {
@@ -113,8 +113,7 @@ public class TownHallBlock extends Block {
 
         LedgerItem.setVillageUUID(heldItem, village.getVillageId());
 
-        OpenTownHallScreenPacket packet = new OpenTownHallScreenPacket(village.getVillageId(), village.getVillageName());
-        NetworkHandler.CHANNEL.sendTo(packet, serverPlayer.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+        OpenTownHallScreen.send(serverPlayer, village.getVillageId(), village.getVillageName());
 
         return InteractionResult.SUCCESS;
     }
@@ -167,7 +166,7 @@ public class TownHallBlock extends Block {
 
     private void onPlaced(ServerLevel level, BlockPos pos, Player player) {
         ChunkPos chunkPos = new ChunkPos(pos);
-        
+
         IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY)
                 .orElseThrow(NullPointerException::new);
         handleVillageSetup(level, pos, chunkPos, player, villagesCapability);

--- a/src/main/java/org/sosly/villagetale/capability/village/VillageCapability.java
+++ b/src/main/java/org/sosly/villagetale/capability/village/VillageCapability.java
@@ -15,10 +15,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.sosly.villagetale.api.IVillageZone;
-import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import net.minecraftforge.network.PacketDistributor;
 
 public class VillageCapability implements IVillageCapability {
@@ -82,7 +81,7 @@ public class VillageCapability implements IVillageCapability {
             return;
         }
 
-        ZoneBoundaryPacket packet = zone.getShape().createBoundaryPacket(zone.getUUID(), this.id);
+        ZoneBoundary packet = zone.getShape().createBoundaryPacket(zone.getUUID(), this.id);
         NetworkHandler.CHANNEL.send(
             PacketDistributor.DIMENSION.with(() -> chunk.get().getLevel().dimension()),
             packet

--- a/src/main/java/org/sosly/villagetale/capability/villages/VillagesCapability.java
+++ b/src/main/java/org/sosly/villagetale/capability/villages/VillagesCapability.java
@@ -12,7 +12,7 @@ import net.minecraftforge.network.PacketDistributor;
 import org.sosly.villagetale.api.capability.IVillagesCapability;
 import org.sosly.villagetale.data.VillageInfo;
 import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.clientbound.VillageBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.VillageBoundary;
 
 public class VillagesCapability implements IVillagesCapability {
 
@@ -73,7 +73,7 @@ public class VillagesCapability implements IVillagesCapability {
             return villageId;
         }
 
-        VillageBoundaryPacket packet = new VillageBoundaryPacket(
+        VillageBoundary packet = new VillageBoundary(
             villageId,
             villageStartingChunk,
             squadius

--- a/src/main/java/org/sosly/villagetale/client/gui/AbstractLedgerScreen.java
+++ b/src/main/java/org/sosly/villagetale/client/gui/AbstractLedgerScreen.java
@@ -1,0 +1,55 @@
+package org.sosly.villagetale.client.gui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.sosly.villagetale.VillageTale;
+
+@OnlyIn(Dist.CLIENT)
+public abstract class AbstractLedgerScreen extends Screen {
+    protected static final ResourceLocation LEDGER_TEXTURE = new ResourceLocation(VillageTale.MOD_ID, "textures/gui/ledger.png");
+    protected static final int TEXTURE_WIDTH = 256;
+    protected static final int TEXTURE_HEIGHT = 256;
+    protected static final int GUI_WIDTH = 146;
+    protected static final int GUI_HEIGHT = 180;
+    protected static final int VERTICAL_OFFSET = 20;
+    protected static final int HORIZONTAL_OFFSET = 1;
+
+    protected AbstractLedgerScreen(Component title) {
+        super(title);
+    }
+
+    protected int getLeftPos() {
+        return (this.width - GUI_WIDTH) / 2;
+    }
+
+    protected int getTopPos() {
+        return (this.height - GUI_HEIGHT) / 2;
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        this.renderBackground(guiGraphics);
+
+        int leftPos = getLeftPos();
+        int topPos = getTopPos();
+
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        guiGraphics.blit(LEDGER_TEXTURE, leftPos, topPos, VERTICAL_OFFSET, HORIZONTAL_OFFSET, GUI_WIDTH, GUI_HEIGHT, TEXTURE_WIDTH, TEXTURE_HEIGHT);
+
+        renderLedgerContent(guiGraphics, leftPos, topPos, mouseX, mouseY, partialTick);
+
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    protected abstract void renderLedgerContent(GuiGraphics guiGraphics, int leftPos, int topPos, int mouseX, int mouseY, float partialTick);
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/client/gui/TownHallScreen.java
+++ b/src/main/java/org/sosly/villagetale/client/gui/TownHallScreen.java
@@ -1,30 +1,17 @@
 package org.sosly.villagetale.client.gui;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import org.sosly.villagetale.VillageTale;
-import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfoPacket;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfo;
 
 import java.util.UUID;
 
 @OnlyIn(Dist.CLIENT)
-public class TownHallScreen extends Screen {
-    private static final ResourceLocation LEDGER_TEXTURE = new ResourceLocation(VillageTale.MOD_ID, "textures/gui/ledger.png");
-    private static final int TEXTURE_WIDTH = 256;
-    private static final int TEXTURE_HEIGHT = 256;
-    private static final int GUI_WIDTH = 146;
-    private static final int GUI_HEIGHT = 180;
-    private static final int VERTICAL_OFFSET = 20;
-    private static final int HORIZONTAL_OFFSET = 1;
-
+public class TownHallScreen extends AbstractLedgerScreen {
     private final UUID villageId;
     private final String currentName;
     private EditBox nameField;
@@ -41,8 +28,8 @@ public class TownHallScreen extends Screen {
     protected void init() {
         super.init();
 
-        int leftPos = (this.width - GUI_WIDTH) / 2;
-        int topPos = (this.height - GUI_HEIGHT) / 2;
+        int leftPos = getLeftPos();
+        int topPos = getTopPos();
 
         Component nameMessage = Component.translatable("villagetale.gui.townhall.village_name");
         this.nameField = new NoShadowEditBox(this.font, leftPos + 20, topPos + 40,  GUI_WIDTH - 40, 10, nameMessage);
@@ -72,26 +59,11 @@ public class TownHallScreen extends Screen {
     }
 
     @Override
-    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        this.renderBackground(guiGraphics);
-
-        int leftPos = (this.width - GUI_WIDTH) / 2;
-        int topPos = (this.height - GUI_HEIGHT) / 2;
-
-        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        guiGraphics.blit(LEDGER_TEXTURE, leftPos, topPos, VERTICAL_OFFSET, HORIZONTAL_OFFSET, GUI_WIDTH, GUI_HEIGHT, TEXTURE_WIDTH, TEXTURE_HEIGHT);
-
+    protected void renderLedgerContent(GuiGraphics guiGraphics, int leftPos, int topPos, int mouseX, int mouseY, float partialTick) {
         guiGraphics.drawString(this.font, Component.translatable("villagetale.gui.townhall.village_name_label"), leftPos + 20, topPos + 28, 0x3F3F3F, false);
-
-        super.render(guiGraphics, mouseX, mouseY, partialTick);
 
         int underlineY = topPos + 40 + 14;
         guiGraphics.fill(leftPos + 20, underlineY, leftPos + GUI_WIDTH - 20, underlineY + 1, 0xFF3F3F3F);
-    }
-
-    @Override
-    public boolean isPauseScreen() {
-        return false;
     }
 
     private void onSave() {
@@ -101,8 +73,7 @@ public class TownHallScreen extends Screen {
         }
 
         if (!newName.equals(currentName)) {
-            UpdateVillageInfoPacket packet = new UpdateVillageInfoPacket(villageId, newName);
-            NetworkHandler.CHANNEL.sendToServer(packet);
+            UpdateVillageInfo.send(villageId, newName);
         }
 
         this.onClose();

--- a/src/main/java/org/sosly/villagetale/client/gui/VillagerConversionScreen.java
+++ b/src/main/java/org/sosly/villagetale/client/gui/VillagerConversionScreen.java
@@ -1,0 +1,72 @@
+package org.sosly.villagetale.client.gui;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.sosly.villagetale.event.VillagerInteractionHandler;
+import org.sosly.villagetale.network.packets.serverbound.ConvertVillager;
+
+@OnlyIn(Dist.CLIENT)
+public class VillagerConversionScreen extends AbstractLedgerScreen {
+    private static final int EMERALD_COST = 10;
+
+    private final int villagerEntityId;
+
+    public VillagerConversionScreen(int villagerEntityId) {
+        super(Component.translatable("villagetale.gui.conversion.title"));
+        this.villagerEntityId = villagerEntityId;
+    }
+
+    @Override
+    public void onClose() {
+        VillagerInteractionHandler.releaseVillager(villagerEntityId);
+        super.onClose();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        int leftPos = getLeftPos();
+        int topPos = getTopPos();
+
+        Button commit = Button.builder(
+                        Component.translatable("villagetale.gui.conversion.commit"),
+                        button -> this.onPurchase()
+                )
+                .bounds(leftPos + 25, topPos + GUI_HEIGHT - 40, 40, 14)
+                .build();
+        this.addRenderableWidget(commit);
+
+        Button cancel = Button.builder(
+                        Component.translatable("villagetale.gui.conversion.cancel"),
+                        button -> this.onClose()
+                )
+                .bounds(leftPos + GUI_WIDTH - 65, topPos + GUI_HEIGHT - 40, 40, 14)
+                .build();
+        this.addRenderableWidget(cancel);
+    }
+
+    @Override
+    protected void renderLedgerContent(GuiGraphics guiGraphics, int leftPos, int topPos, int mouseX, int mouseY, float partialTick) {
+        Component itemName = Items.EMERALD.getDescription();
+        Component message = Component.translatable("villagetale.gui.conversion.message", EMERALD_COST, itemName);
+
+        int maxWidth = GUI_WIDTH - 40;
+        var wrappedLines = this.font.split(message, maxWidth);
+
+        int y = topPos + 28;
+        for (var line : wrappedLines) {
+            guiGraphics.drawString(this.font, line, leftPos + 20, y, 0x3F3F3F, false);
+            y += this.font.lineHeight + 2;
+        }
+    }
+
+    private void onPurchase() {
+        ConvertVillager.send(villagerEntityId);
+        this.onClose();
+    }
+}

--- a/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
+++ b/src/main/java/org/sosly/villagetale/entity/MemoryModuleTypes.java
@@ -82,6 +82,10 @@ public class MemoryModuleTypes {
             MEMORY_MODULE_TYPES.register("home_zone",
                     () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
 
+    public static final RegistryObject<MemoryModuleType<UUID>> FOLLOWING_PLAYER =
+            MEMORY_MODULE_TYPES.register("following_player",
+                    () -> new MemoryModuleType<>(Optional.of(Codecs.UUID)));
+
     public static final RegistryObject<MemoryModuleType<Boolean>> BUSY =
             MEMORY_MODULE_TYPES.register("busy",
                     () -> new MemoryModuleType<>(Optional.of(Codec.BOOL)));

--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -27,9 +27,9 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.ai.Brain;
@@ -50,7 +50,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BedBlock;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -201,6 +200,9 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
     @Override
     protected void customServerAiStep() {
         this.level().getProfiler().push("villageTaleVillagerBrain");
+        if (!this.getBrain().isActive(Activity.CORE)) {
+            this.registerBrainGoals(this.getBrain());
+        }
         this.getBrain().tick((ServerLevel) this.level(), this);
         this.level().getProfiler().pop();
         this.foodData.tick(this);
@@ -258,6 +260,11 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         if (homeZoneId.isPresent()) {
             tag.putString("HomeZoneId", homeZoneId.get().toString());
         }
+
+        Optional<UUID> followingPlayerId = this.brain.getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get());
+        if (followingPlayerId.isPresent()) {
+            tag.putString("FollowingPlayerId", followingPlayerId.get().toString());
+        }
     }
 
     @Override
@@ -299,6 +306,11 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         if (tag.contains("HomeZoneId")) {
             UUID homeZoneId = UUID.fromString(tag.getString("HomeZoneId"));
             this.brain.setMemory(MemoryModuleTypes.HOME_ZONE.get(), homeZoneId);
+        }
+
+        if (tag.contains("FollowingPlayerId")) {
+            UUID followingPlayerId = UUID.fromString(tag.getString("FollowingPlayerId"));
+            this.brain.setMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get(), followingPlayerId);
         }
 
         if (this.level() instanceof ServerLevel serverLevel) {
@@ -395,7 +407,7 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         this.brain.eraseMemory(MemoryModuleTypes.NEAREST_HARVESTABLE_CROP.get());
         this.brain.eraseMemory(MemoryModuleTypes.NEAREST_TILLABLE_SOIL.get());
         this.brain.eraseMemory(MemoryModuleTypes.BUSY.get());
-        
+
         this.brain.setMemory(MemoryModuleTypes.PROFESSION.get(), professionId);
 
         if (!(this.level() instanceof ServerLevel serverLevel)) {
@@ -459,13 +471,12 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         }
 
         newVillageCapability.addVillagerByUUID(this.getUUID());
-        
-        // Clear all zone-related memories when changing villages
+
         this.brain.eraseMemory(MemoryModuleTypes.HOME_ZONE.get());
         this.brain.eraseMemory(MemoryModuleTypes.WORK_ZONE.get());
         this.brain.eraseMemory(MemoryModuleTypes.WORK_POS.get());
         this.brain.eraseMemory(net.minecraft.world.entity.ai.memory.MemoryModuleType.HOME);
-        
+
         this.brain.setMemory(MemoryModuleTypes.VILLAGE.get(), villageId);
         VillageTale.LOGGER.info("Villager {} assigned to village {}", this.getUUID(), villageId);
     }
@@ -507,6 +518,19 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
 
         this.brain.eraseMemory(MemoryModuleTypes.VILLAGE.get());
         VillageTale.LOGGER.info("Villager {} village assignment cleared", this.getUUID());
+    }
+
+    public Optional<UUID> getFollowingPlayer() {
+        return this.brain.getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get());
+    }
+
+    public void setFollowingPlayer(@Nullable UUID playerId) {
+        if (playerId == null) {
+            this.brain.eraseMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get());
+            return;
+        }
+
+        this.brain.setMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get(), playerId);
     }
 
     public LivingEntityFoodData getFoodData() {
@@ -596,7 +620,8 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
                 MemoryModuleTypes.WORK_ZONE.get(),
                 MemoryModuleTypes.HOME_ZONE.get(),
                 MemoryModuleTypes.BUSY.get(),
-                MemoryModuleTypes.GATES_TO_CLOSE.get()
+                MemoryModuleTypes.GATES_TO_CLOSE.get(),
+                MemoryModuleTypes.FOLLOWING_PLAYER.get()
             );
         }
 

--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/FollowPlayer.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/FollowPlayer.java
@@ -1,0 +1,99 @@
+package org.sosly.villagetale.entity.ai.behavior;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+import net.minecraft.world.entity.ai.memory.WalkTarget;
+import net.minecraft.world.entity.player.Player;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+
+import java.util.UUID;
+
+public class FollowPlayer extends Behavior<Villager> {
+    private static final double FOLLOW_DISTANCE = 3.0D;
+    private static final int WALK_PRECISION = 0;
+    private final float speedModifier;
+
+    public FollowPlayer(float speedModifier) {
+        super(ImmutableMap.of(
+            MemoryModuleTypes.FOLLOWING_PLAYER.get(), MemoryStatus.VALUE_PRESENT,
+            MemoryModuleType.WALK_TARGET, MemoryStatus.REGISTERED
+        ), 200);
+        this.speedModifier = speedModifier;
+    }
+
+    public static BehaviorControl<Villager> create(float speedModifier) {
+        return new FollowPlayer(speedModifier);
+    }
+
+    @Override
+    protected boolean checkExtraStartConditions(ServerLevel level, Villager villager) {
+        UUID playerId = villager.getBrain().getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get()).orElse(null);
+        if (playerId == null) {
+            return false;
+        }
+
+        Player player = level.getPlayerByUUID(playerId);
+        if (player == null) {
+            return false;
+        }
+
+        return !villager.position().closerThan(player.position(), FOLLOW_DISTANCE);
+    }
+
+    @Override
+    protected void start(ServerLevel level, Villager villager, long gameTime) {
+        UUID playerId = villager.getBrain().getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get()).orElse(null);
+        if (playerId == null) {
+            return;
+        }
+
+        Player player = level.getPlayerByUUID(playerId);
+        if (player == null) {
+            return;
+        }
+
+        villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+            new WalkTarget(player, speedModifier, WALK_PRECISION));
+    }
+
+    @Override
+    protected boolean canStillUse(ServerLevel level, Villager villager, long gameTime) {
+        UUID playerId = villager.getBrain().getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get()).orElse(null);
+        if (playerId == null) {
+            return false;
+        }
+
+        Player player = level.getPlayerByUUID(playerId);
+        if (player == null) {
+            return false;
+        }
+
+        return !villager.position().closerThan(player.position(), FOLLOW_DISTANCE);
+    }
+
+    @Override
+    protected void tick(ServerLevel level, Villager villager, long gameTime) {
+        UUID playerId = villager.getBrain().getMemory(MemoryModuleTypes.FOLLOWING_PLAYER.get()).orElse(null);
+        if (playerId == null) {
+            return;
+        }
+
+        Player player = level.getPlayerByUUID(playerId);
+        if (player == null) {
+            return;
+        }
+
+        villager.getBrain().setMemory(MemoryModuleType.WALK_TARGET,
+            new WalkTarget(player, speedModifier, WALK_PRECISION));
+    }
+
+    @Override
+    protected void stop(ServerLevel level, Villager villager, long gameTime) {
+        villager.getBrain().eraseMemory(MemoryModuleType.WALK_TARGET);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/entity/ai/goals/VillagerGoalPackages.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/goals/VillagerGoalPackages.java
@@ -22,6 +22,7 @@ import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.entity.ai.behavior.CloseOpenedGates;
 import org.sosly.villagetale.entity.ai.behavior.EatFood;
+import org.sosly.villagetale.entity.ai.behavior.FollowPlayer;
 import org.sosly.villagetale.entity.ai.behavior.GetFromContainer;
 import org.sosly.villagetale.entity.ai.behavior.GoToAssignedBed;
 import org.sosly.villagetale.entity.ai.behavior.GoToNearestStorage;
@@ -44,6 +45,7 @@ public class VillagerGoalPackages {
             Pair.of(0, CloseOpenedGates.create()),
             Pair.of(0, new LookAtTargetSink(45, 90)),
             Pair.of(0, VillagerPanicTrigger.create()),
+            Pair.of(0, FollowPlayer.create(0.6F)),
             Pair.of(1, new MoveToTargetSink()),
             Pair.of(1, new WakeUp()),
             Pair.of(2, new EatFood()),

--- a/src/main/java/org/sosly/villagetale/event/BoundarySyncHandler.java
+++ b/src/main/java/org/sosly/villagetale/event/BoundarySyncHandler.java
@@ -9,12 +9,11 @@ import net.minecraftforge.network.PacketDistributor;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.capability.IVillageCapability;
-import org.sosly.villagetale.api.capability.IVillagesCapability;
 import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.VillageInfo;
 import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.clientbound.VillageBoundaryPacket;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.VillageBoundary;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 
 @Mod.EventBusSubscriber(modid = VillageTale.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class BoundarySyncHandler {
@@ -42,7 +41,7 @@ public class BoundarySyncHandler {
 
         level.getCapability(Capabilities.VILLAGES_CAPABILITY).ifPresent(villagesCapability -> {
             for (VillageInfo villageInfo : villagesCapability.getVillages()) {
-                VillageBoundaryPacket packet = new VillageBoundaryPacket(
+                VillageBoundary packet = new VillageBoundary(
                     villageInfo.getVillageId(),
                     villageInfo.getVillageStartingChunk(),
                     villageInfo.getSquadius()
@@ -65,7 +64,7 @@ public class BoundarySyncHandler {
                 continue;
             }
 
-            ZoneBoundaryPacket packet = zone.getShape().createBoundaryPacket(
+            ZoneBoundary packet = zone.getShape().createBoundaryPacket(
                 zone.getUUID(),
                 villageCapability.getUUID()
             );

--- a/src/main/java/org/sosly/villagetale/event/VillagerInteractionHandler.java
+++ b/src/main/java/org/sosly/villagetale/event/VillagerInteractionHandler.java
@@ -1,0 +1,73 @@
+package org.sosly.villagetale.event;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.item.LedgerItem;
+import org.sosly.villagetale.network.packets.clientbound.OpenVillagerConversionScreen;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Mod.EventBusSubscriber(modid = VillageTale.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class VillagerInteractionHandler {
+    private static final Set<Integer> villagersInConversation = new HashSet<>();
+
+    @SubscribeEvent
+    public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
+        if (!(event.getTarget() instanceof Villager villager)) {
+            return;
+        }
+
+        Player player = event.getEntity();
+        InteractionHand hand = event.getHand();
+        ItemStack stack = player.getItemInHand(hand);
+
+        if (!(stack.getItem() instanceof LedgerItem)) {
+            return;
+        }
+
+        if (player.level().isClientSide) {
+            return;
+        }
+
+        if (player instanceof ServerPlayer serverPlayer) {
+            villager.getNavigation().stop();
+            villager.lookAt(player, 180.0F, 180.0F);
+            villagersInConversation.add(villager.getId());
+
+            OpenVillagerConversionScreen.send(serverPlayer, event.getTarget().getId());
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || villagersInConversation.isEmpty()) {
+            return;
+        }
+
+        villagersInConversation.removeIf(id -> {
+            for (var level : event.getServer().getAllLevels()) {
+                Entity entity = level.getEntity(id);
+                if (entity instanceof Villager villager) {
+                    villager.getNavigation().stop();
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    public static void releaseVillager(int villagerId) {
+        villagersInConversation.remove(villagerId);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
+++ b/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
@@ -10,90 +10,67 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.entity.Villager;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import org.sosly.villagetale.network.packets.clientbound.OpenTownHallScreenPacket;
-import org.sosly.villagetale.network.packets.clientbound.VillagerEquipmentSyncPacket;
-import org.sosly.villagetale.network.packets.clientbound.VillagerProfessionSyncPacket;
-import org.sosly.villagetale.network.packets.clientbound.VillageBoundaryPacket;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
-import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfoPacket;
+import org.sosly.villagetale.network.packets.clientbound.OpenTownHallScreen;
+import org.sosly.villagetale.network.packets.clientbound.OpenVillagerConversionScreen;
+import org.sosly.villagetale.network.packets.clientbound.VillageBoundary;
+import org.sosly.villagetale.network.packets.clientbound.VillagerEquipmentSync;
+import org.sosly.villagetale.network.packets.clientbound.VillagerProfessionSync;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
+import org.sosly.villagetale.network.packets.serverbound.ConvertVillager;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfo;
 
 public class NetworkHandler {
     private static final String PROTOCOL_VERSION = "1";
-    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
-        new ResourceLocation(VillageTale.MOD_ID, "main"),
-        () -> PROTOCOL_VERSION,
-        PROTOCOL_VERSION::equals,
-        PROTOCOL_VERSION::equals
-    );
+    private static final ResourceLocation CHANNEL_NAME = new ResourceLocation(VillageTale.MOD_ID, "main");
+
+    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(CHANNEL_NAME, () -> PROTOCOL_VERSION,
+            PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
 
     private static int packetId = 0;
 
     public static void init() {
-        CHANNEL.registerMessage(
-            packetId++,
-            VillagerProfessionSyncPacket.class,
-            VillagerProfessionSyncPacket::encode,
-            VillagerProfessionSyncPacket::decode,
-            VillagerProfessionSyncPacket::handle
+        CHANNEL.registerMessage(packetId++, VillagerProfessionSync.class,
+                VillagerProfessionSync::encode, VillagerProfessionSync::decode, VillagerProfessionSync::handle);
+
+        CHANNEL.registerMessage(packetId++, VillagerEquipmentSync.class,
+                VillagerEquipmentSync::encode, VillagerEquipmentSync::decode, VillagerEquipmentSync::handle
         );
 
-        CHANNEL.registerMessage(
-            packetId++,
-            VillagerEquipmentSyncPacket.class,
-            VillagerEquipmentSyncPacket::encode,
-            VillagerEquipmentSyncPacket::decode,
-            VillagerEquipmentSyncPacket::handle
-        );
+        CHANNEL.registerMessage(packetId++, VillageBoundary.class,
+                VillageBoundary::encode, VillageBoundary::decode, VillageBoundary::handle);
 
-        CHANNEL.registerMessage(
-            packetId++,
-            VillageBoundaryPacket.class,
-            VillageBoundaryPacket::encode,
-            VillageBoundaryPacket::decode,
-            VillageBoundaryPacket::handle
-        );
+        CHANNEL.registerMessage(packetId++, ZoneBoundary.class,
+                ZoneBoundary::encode, ZoneBoundary::decode, ZoneBoundary::handle);
 
-        CHANNEL.registerMessage(
-            packetId++,
-            ZoneBoundaryPacket.class,
-            ZoneBoundaryPacket::encode,
-            ZoneBoundaryPacket::decode,
-            ZoneBoundaryPacket::handle
-        );
+        CHANNEL.registerMessage(packetId++, UpdateVillageInfo.class,
+                UpdateVillageInfo::encode, UpdateVillageInfo::decode, UpdateVillageInfo::handle);
 
-        CHANNEL.registerMessage(
-            packetId++,
-            UpdateVillageInfoPacket.class,
-            UpdateVillageInfoPacket::encode,
-            UpdateVillageInfoPacket::decode,
-            UpdateVillageInfoPacket::handle
-        );
+        CHANNEL.registerMessage(packetId++, OpenTownHallScreen.class,
+                OpenTownHallScreen::encode, OpenTownHallScreen::decode, OpenTownHallScreen::handle);
 
-        CHANNEL.registerMessage(
-            packetId++,
-            OpenTownHallScreenPacket.class,
-            OpenTownHallScreenPacket::encode,
-            OpenTownHallScreenPacket::decode,
-            OpenTownHallScreenPacket::handle
-        );
+        CHANNEL.registerMessage(packetId++, OpenVillagerConversionScreen.class,
+                OpenVillagerConversionScreen::encode, OpenVillagerConversionScreen::decode, OpenVillagerConversionScreen::handle);
+
+        CHANNEL.registerMessage(packetId++, ConvertVillager.class,
+                ConvertVillager::encode, ConvertVillager::decode, ConvertVillager::handle);
 
         VillageTale.LOGGER.info("VillageTale registered {} network messages", packetId);
     }
 
     public static void syncProfessionToPlayer(Villager villager, ServerPlayer player) {
         ResourceLocation professionId = villager.getProfession().getID();
-        VillagerProfessionSyncPacket packet = new VillagerProfessionSyncPacket(villager.getId(), professionId);
+        VillagerProfessionSync packet = new VillagerProfessionSync(villager.getId(), professionId);
         CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
     }
 
     public static void syncProfessionToNearbyPlayers(Villager villager) {
         ResourceLocation professionId = villager.getProfession().getID();
-        VillagerProfessionSyncPacket packet = new VillagerProfessionSyncPacket(villager.getId(), professionId);
+        VillagerProfessionSync packet = new VillagerProfessionSync(villager.getId(), professionId);
         CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> villager), packet);
     }
-    
+
     public static void syncEquipmentToNearbyPlayers(Villager villager, InteractionHand hand, ItemStack itemStack) {
-        VillagerEquipmentSyncPacket packet = new VillagerEquipmentSyncPacket(villager.getId(), hand, itemStack);
+        VillagerEquipmentSync packet = new VillagerEquipmentSync(villager.getId(), hand, itemStack);
         CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> villager), packet);
     }
 }

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenTownHallScreen.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenTownHallScreen.java
@@ -2,38 +2,46 @@ package org.sosly.villagetale.network.packets.clientbound;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.client.gui.TownHallScreen;
 import org.sosly.villagetale.network.BasePacket;
 import org.sosly.villagetale.network.ClientPacketHandler;
+import org.sosly.villagetale.network.NetworkHandler;
 
 import java.util.UUID;
 import java.util.function.Supplier;
 
-public class OpenTownHallScreenPacket extends BasePacket {
+public class OpenTownHallScreen extends BasePacket {
     private final UUID villageId;
     private final String villageName;
 
-    public OpenTownHallScreenPacket(UUID villageId, String villageName) {
+    private OpenTownHallScreen(UUID villageId, String villageName) {
         this.villageId = villageId;
         this.villageName = villageName;
     }
 
-    public static void encode(OpenTownHallScreenPacket msg, FriendlyByteBuf buffer) {
+    public static void send(ServerPlayer player, UUID villageId, String villageName) {
+        OpenTownHallScreen packet = new OpenTownHallScreen(villageId, villageName);
+        NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+    }
+
+    public static void encode(OpenTownHallScreen msg, FriendlyByteBuf buffer) {
         buffer.writeUUID(msg.villageId);
         buffer.writeUtf(msg.villageName);
     }
 
-    public static OpenTownHallScreenPacket decode(FriendlyByteBuf buffer) {
-        OpenTownHallScreenPacket msg;
+    public static OpenTownHallScreen decode(FriendlyByteBuf buffer) {
+        OpenTownHallScreen msg;
 
         try {
             UUID villageId = buffer.readUUID();
             String villageName = buffer.readUtf();
-            msg = new OpenTownHallScreenPacket(villageId, villageName);
+            msg = new OpenTownHallScreen(villageId, villageName);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading OpenTownHallScreenPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading OpenTownHallScreen: {}", err.toString());
             return null;
         }
 
@@ -41,7 +49,7 @@ public class OpenTownHallScreenPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(OpenTownHallScreenPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(OpenTownHallScreen msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (!ClientPacketHandler.validateBasics(msg, context)) {
             return;

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerConversionScreen.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerConversionScreen.java
@@ -1,0 +1,62 @@
+package org.sosly.villagetale.network.packets.clientbound;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.client.gui.VillagerConversionScreen;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.ClientPacketHandler;
+import org.sosly.villagetale.network.NetworkHandler;
+
+import java.util.function.Supplier;
+
+public class OpenVillagerConversionScreen extends BasePacket {
+    private final int villagerEntityId;
+
+    private OpenVillagerConversionScreen(int villagerEntityId) {
+        this.villagerEntityId = villagerEntityId;
+    }
+
+    public static void send(ServerPlayer player, int villagerEntityId) {
+        OpenVillagerConversionScreen packet = new OpenVillagerConversionScreen(villagerEntityId);
+        NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+    }
+
+    public static void encode(OpenVillagerConversionScreen msg, FriendlyByteBuf buffer) {
+        buffer.writeInt(msg.villagerEntityId);
+    }
+
+    public static OpenVillagerConversionScreen decode(FriendlyByteBuf buffer) {
+        OpenVillagerConversionScreen msg;
+
+        try {
+            int villagerEntityId = buffer.readInt();
+            msg = new OpenVillagerConversionScreen(villagerEntityId);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading OpenVillagerConversionScreen: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(OpenVillagerConversionScreen msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (!ClientPacketHandler.validateBasics(msg, context)) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            Minecraft mc = Minecraft.getInstance();
+            mc.setScreen(new VillagerConversionScreen(msg.villagerEntityId));
+        });
+    }
+
+    public int getVillagerEntityId() {
+        return villagerEntityId;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillageBoundary.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillageBoundary.java
@@ -13,35 +13,35 @@ import org.sosly.villagetale.network.ClientPacketHandler;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-public class VillageBoundaryPacket extends BasePacket {
+public class VillageBoundary extends BasePacket {
     private final UUID villageId;
     private final ChunkPos centerChunk;
     private final int squadius;
 
-    public VillageBoundaryPacket(UUID villageId, ChunkPos centerChunk, int squadius) {
+    public VillageBoundary(UUID villageId, ChunkPos centerChunk, int squadius) {
         this.villageId = villageId;
         this.centerChunk = centerChunk;
         this.squadius = squadius;
     }
 
-    public static void encode(VillageBoundaryPacket msg, FriendlyByteBuf buffer) {
+    public static void encode(VillageBoundary msg, FriendlyByteBuf buffer) {
         buffer.writeUUID(msg.villageId);
         buffer.writeVarInt(msg.centerChunk.x);
         buffer.writeVarInt(msg.centerChunk.z);
         buffer.writeVarInt(msg.squadius);
     }
 
-    public static VillageBoundaryPacket decode(FriendlyByteBuf buffer) {
-        VillageBoundaryPacket msg;
+    public static VillageBoundary decode(FriendlyByteBuf buffer) {
+        VillageBoundary msg;
 
         try {
             UUID villageId = buffer.readUUID();
             int chunkX = buffer.readVarInt();
             int chunkZ = buffer.readVarInt();
             int squadius = buffer.readVarInt();
-            msg = new VillageBoundaryPacket(villageId, new ChunkPos(chunkX, chunkZ), squadius);
+            msg = new VillageBoundary(villageId, new ChunkPos(chunkX, chunkZ), squadius);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading VillageBoundaryPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading VillageBoundary: {}", err.toString());
             return null;
         }
 
@@ -49,7 +49,7 @@ public class VillageBoundaryPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(VillageBoundaryPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(VillageBoundary msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (ClientPacketHandler.validateBasics(msg, context)) {
             context.enqueueWork(() -> {

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerEquipmentSync.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerEquipmentSync.java
@@ -13,33 +13,33 @@ import org.sosly.villagetale.network.ClientPacketHandler;
 
 import java.util.function.Supplier;
 
-public class VillagerEquipmentSyncPacket extends BasePacket {
+public class VillagerEquipmentSync extends BasePacket {
     private final int entityId;
     private final InteractionHand hand;
     private final ItemStack itemStack;
 
-    public VillagerEquipmentSyncPacket(int entityId, InteractionHand hand, ItemStack itemStack) {
+    public VillagerEquipmentSync(int entityId, InteractionHand hand, ItemStack itemStack) {
         this.entityId = entityId;
         this.hand = hand;
         this.itemStack = itemStack.copy();
     }
 
-    public static void encode(VillagerEquipmentSyncPacket msg, FriendlyByteBuf buffer) {
+    public static void encode(VillagerEquipmentSync msg, FriendlyByteBuf buffer) {
         buffer.writeVarInt(msg.entityId);
         buffer.writeEnum(msg.hand);
         buffer.writeItem(msg.itemStack);
     }
 
-    public static VillagerEquipmentSyncPacket decode(FriendlyByteBuf buffer) {
-        VillagerEquipmentSyncPacket msg;
+    public static VillagerEquipmentSync decode(FriendlyByteBuf buffer) {
+        VillagerEquipmentSync msg;
 
         try {
             int entityId = buffer.readVarInt();
             InteractionHand hand = buffer.readEnum(InteractionHand.class);
             ItemStack itemStack = buffer.readItem();
-            msg = new VillagerEquipmentSyncPacket(entityId, hand, itemStack);
+            msg = new VillagerEquipmentSync(entityId, hand, itemStack);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading VillagerEquipmentSyncPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading VillagerEquipmentSync: {}", err.toString());
             return null;
         }
 
@@ -47,7 +47,7 @@ public class VillagerEquipmentSyncPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(VillagerEquipmentSyncPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(VillagerEquipmentSync msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (ClientPacketHandler.validateBasics(msg, context)) {
             context.enqueueWork(() -> {

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerProfessionSync.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerProfessionSync.java
@@ -12,29 +12,29 @@ import org.sosly.villagetale.network.ClientPacketHandler;
 
 import java.util.function.Supplier;
 
-public class VillagerProfessionSyncPacket extends BasePacket {
+public class VillagerProfessionSync extends BasePacket {
     private final int entityId;
     private final ResourceLocation professionId;
 
-    public VillagerProfessionSyncPacket(int entityId, ResourceLocation professionId) {
+    public VillagerProfessionSync(int entityId, ResourceLocation professionId) {
         this.entityId = entityId;
         this.professionId = professionId;
     }
 
-    public static void encode(VillagerProfessionSyncPacket msg, FriendlyByteBuf buffer) {
+    public static void encode(VillagerProfessionSync msg, FriendlyByteBuf buffer) {
         buffer.writeVarInt(msg.entityId);
         buffer.writeResourceLocation(msg.professionId);
     }
 
-    public static VillagerProfessionSyncPacket decode(FriendlyByteBuf buffer) {
-        VillagerProfessionSyncPacket msg;
+    public static VillagerProfessionSync decode(FriendlyByteBuf buffer) {
+        VillagerProfessionSync msg;
 
         try {
             int entityId = buffer.readVarInt();
             ResourceLocation professionId = buffer.readResourceLocation();
-            msg = new VillagerProfessionSyncPacket(entityId, professionId);
+            msg = new VillagerProfessionSync(entityId, professionId);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading VillagerProfessionSyncPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading VillagerProfessionSync: {}", err.toString());
             return null;
         }
 
@@ -42,7 +42,7 @@ public class VillagerProfessionSyncPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(VillagerProfessionSyncPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(VillagerProfessionSync msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (ClientPacketHandler.validateBasics(msg, context)) {
             context.enqueueWork(() -> {

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/ZoneBoundary.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/ZoneBoundary.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-public class ZoneBoundaryPacket extends BasePacket {
+public class ZoneBoundary extends BasePacket {
     private final UUID zoneId;
     private final UUID villageId;
     private final ResourceLocation shapeType;
@@ -27,12 +27,12 @@ public class ZoneBoundaryPacket extends BasePacket {
     private final int height;
     private final List<BlockPos> waypoints;
 
-    public ZoneBoundaryPacket(UUID zoneId, UUID villageId, ResourceLocation shapeType, AABB bounds) {
+    public ZoneBoundary(UUID zoneId, UUID villageId, ResourceLocation shapeType, AABB bounds) {
         this(zoneId, villageId, shapeType, bounds, null, 0, 0, null);
     }
 
-    public ZoneBoundaryPacket(UUID zoneId, UUID villageId, ResourceLocation shapeType, AABB bounds,
-                             BlockPos center, int radius, int height, List<BlockPos> waypoints) {
+    public ZoneBoundary(UUID zoneId, UUID villageId, ResourceLocation shapeType, AABB bounds,
+                        BlockPos center, int radius, int height, List<BlockPos> waypoints) {
         this.zoneId = zoneId;
         this.villageId = villageId;
         this.shapeType = shapeType;
@@ -43,7 +43,7 @@ public class ZoneBoundaryPacket extends BasePacket {
         this.waypoints = waypoints;
     }
 
-    public static void encode(ZoneBoundaryPacket msg, FriendlyByteBuf buffer) {
+    public static void encode(ZoneBoundary msg, FriendlyByteBuf buffer) {
         buffer.writeUUID(msg.zoneId);
         buffer.writeUUID(msg.villageId);
         buffer.writeResourceLocation(msg.shapeType);
@@ -71,8 +71,8 @@ public class ZoneBoundaryPacket extends BasePacket {
         }
     }
 
-    public static ZoneBoundaryPacket decode(FriendlyByteBuf buffer) {
-        ZoneBoundaryPacket msg;
+    public static ZoneBoundary decode(FriendlyByteBuf buffer) {
+        ZoneBoundary msg;
 
         try {
             UUID zoneId = buffer.readUUID();
@@ -103,9 +103,9 @@ public class ZoneBoundaryPacket extends BasePacket {
                 }
             }
 
-            msg = new ZoneBoundaryPacket(zoneId, villageId, shapeType, bounds, center, radius, height, waypoints);
+            msg = new ZoneBoundary(zoneId, villageId, shapeType, bounds, center, radius, height, waypoints);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading ZoneBoundaryPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading ZoneBoundary: {}", err.toString());
             return null;
         }
 
@@ -113,7 +113,7 @@ public class ZoneBoundaryPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(ZoneBoundaryPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(ZoneBoundary msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (ClientPacketHandler.validateBasics(msg, context)) {
             context.enqueueWork(() -> {

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/ConvertVillager.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/ConvertVillager.java
@@ -1,0 +1,144 @@
+package org.sosly.villagetale.network.packets.serverbound;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.entity.EntityTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.NetworkHandler;
+import org.sosly.villagetale.network.ServerPacketHandler;
+
+import java.util.function.Supplier;
+
+public class ConvertVillager extends BasePacket {
+    private static final int EMERALD_COST = 10;
+
+    private final int villagerEntityId;
+
+    private ConvertVillager(int villagerEntityId) {
+        this.villagerEntityId = villagerEntityId;
+    }
+
+    public static void send(int villagerEntityId) {
+        ConvertVillager packet = new ConvertVillager(villagerEntityId);
+        NetworkHandler.CHANNEL.sendToServer(packet);
+    }
+
+    public static void encode(ConvertVillager msg, FriendlyByteBuf buffer) {
+        buffer.writeInt(msg.villagerEntityId);
+    }
+
+    public static ConvertVillager decode(FriendlyByteBuf buffer) {
+        ConvertVillager msg;
+
+        try {
+            int villagerEntityId = buffer.readInt();
+            msg = new ConvertVillager(villagerEntityId);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading ConvertVillager: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(ConvertVillager msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (!ServerPacketHandler.validateBasics(msg, context)) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            ServerPlayer player = context.getSender();
+            if (player == null) {
+                return;
+            }
+
+            ServerLevel level = player.serverLevel();
+            Entity entity = level.getEntity(msg.villagerEntityId);
+
+            if (!(entity instanceof net.minecraft.world.entity.npc.Villager vanillaVillager)) {
+                player.sendSystemMessage(Component.literal("Invalid villager entity"));
+                return;
+            }
+
+            if (!hasEnoughEmeralds(player)) {
+                player.sendSystemMessage(Component.translatable("villagetale.conversion.insufficient_emeralds", EMERALD_COST));
+                return;
+            }
+
+            if (!deductEmeralds(player)) {
+                player.sendSystemMessage(Component.literal("Failed to deduct emeralds"));
+                return;
+            }
+
+            Villager vtVillager = EntityTypes.VILLAGER.get().create(level);
+            if (vtVillager == null) {
+                player.sendSystemMessage(Component.literal("Failed to create VillageTale villager"));
+                refundEmeralds(player);
+                return;
+            }
+
+            vtVillager.moveTo(vanillaVillager.getX(), vanillaVillager.getY(), vanillaVillager.getZ(),
+                vanillaVillager.getYRot(), vanillaVillager.getXRot());
+
+            if (vanillaVillager.hasCustomName()) {
+                vtVillager.setCustomName(vanillaVillager.getCustomName());
+            }
+
+            vtVillager.setFollowingPlayer(player.getUUID());
+
+            level.addFreshEntity(vtVillager);
+            vanillaVillager.discard();
+
+            player.sendSystemMessage(Component.translatable("villagetale.conversion.success"));
+        });
+    }
+
+    private static boolean hasEnoughEmeralds(ServerPlayer player) {
+        int emeraldCount = 0;
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.is(Items.EMERALD)) {
+                emeraldCount += stack.getCount();
+                if (emeraldCount >= EMERALD_COST) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean deductEmeralds(ServerPlayer player) {
+        int remaining = EMERALD_COST;
+        for (int i = 0; i < player.getInventory().items.size(); i++) {
+            ItemStack stack = player.getInventory().items.get(i);
+            if (stack.is(Items.EMERALD)) {
+                int toRemove = Math.min(remaining, stack.getCount());
+                stack.shrink(toRemove);
+                remaining -= toRemove;
+
+                if (remaining == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void refundEmeralds(ServerPlayer player) {
+        ItemStack emeralds = new ItemStack(Items.EMERALD, EMERALD_COST);
+        player.addItem(emeralds);
+    }
+
+    public int getVillagerEntityId() {
+        return villagerEntityId;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/ConvertVillager.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/ConvertVillager.java
@@ -1,5 +1,6 @@
 package org.sosly.villagetale.network.packets.serverbound;
 
+import java.util.function.Supplier;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -14,8 +15,6 @@ import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.network.BasePacket;
 import org.sosly.villagetale.network.NetworkHandler;
 import org.sosly.villagetale.network.ServerPacketHandler;
-
-import java.util.function.Supplier;
 
 public class ConvertVillager extends BasePacket {
     private static final int EMERALD_COST = 10;
@@ -65,7 +64,7 @@ public class ConvertVillager extends BasePacket {
             ServerLevel level = player.serverLevel();
             Entity entity = level.getEntity(msg.villagerEntityId);
 
-            if (!(entity instanceof net.minecraft.world.entity.npc.Villager vanillaVillager)) {
+            if (!(entity instanceof Villager vanillaVillager)) {
                 player.sendSystemMessage(Component.literal("Invalid villager entity"));
                 return;
             }

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillageInfo.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillageInfo.java
@@ -12,34 +12,40 @@ import org.sosly.villagetale.api.capability.IVillagesCapability;
 import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.VillageInfo;
 import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.NetworkHandler;
 import org.sosly.villagetale.network.ServerPacketHandler;
 
 import java.util.UUID;
 import java.util.function.Supplier;
 
-public class UpdateVillageInfoPacket extends BasePacket {
+public class UpdateVillageInfo extends BasePacket {
     private final UUID villageId;
     private final String newName;
 
-    public UpdateVillageInfoPacket(UUID villageId, String newName) {
+    private UpdateVillageInfo(UUID villageId, String newName) {
         this.villageId = villageId;
         this.newName = newName;
     }
 
-    public static void encode(UpdateVillageInfoPacket msg, FriendlyByteBuf buffer) {
+    public static void send(UUID villageId, String newName) {
+        UpdateVillageInfo packet = new UpdateVillageInfo(villageId, newName);
+        NetworkHandler.CHANNEL.sendToServer(packet);
+    }
+
+    public static void encode(UpdateVillageInfo msg, FriendlyByteBuf buffer) {
         buffer.writeUUID(msg.villageId);
         buffer.writeUtf(msg.newName);
     }
 
-    public static UpdateVillageInfoPacket decode(FriendlyByteBuf buffer) {
-        UpdateVillageInfoPacket msg;
+    public static UpdateVillageInfo decode(FriendlyByteBuf buffer) {
+        UpdateVillageInfo msg;
 
         try {
             UUID villageId = buffer.readUUID();
             String newName = buffer.readUtf();
-            msg = new UpdateVillageInfoPacket(villageId, newName);
+            msg = new UpdateVillageInfo(villageId, newName);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
-            VillageTale.LOGGER.error("Exception while reading UpdateVillageInfoPacket: {}", err.toString());
+            VillageTale.LOGGER.error("Exception while reading UpdateVillageInfo: {}", err.toString());
             return null;
         }
 
@@ -47,7 +53,7 @@ public class UpdateVillageInfoPacket extends BasePacket {
         return msg;
     }
 
-    public static void handle(UpdateVillageInfoPacket msg, Supplier<NetworkEvent.Context> ctx) {
+    public static void handle(UpdateVillageInfo msg, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         if (!ServerPacketHandler.validateBasics(msg, context)) {
             return;

--- a/src/main/java/org/sosly/villagetale/zone/Zone.java
+++ b/src/main/java/org/sosly/villagetale/zone/Zone.java
@@ -26,7 +26,7 @@ import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.network.NetworkHandler;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import net.minecraftforge.network.PacketDistributor;
 
 public class Zone implements IVillageZone {
@@ -553,7 +553,7 @@ public class Zone implements IVillageZone {
             return;
         }
 
-        ZoneBoundaryPacket packet = shape.createBoundaryPacket(id, currentVillage.getUUID());
+        ZoneBoundary packet = shape.createBoundaryPacket(id, currentVillage.getUUID());
         if (packet == null) {
             return;
         }

--- a/src/main/java/org/sosly/villagetale/zone/shape/Box.java
+++ b/src/main/java/org/sosly/villagetale/zone/shape/Box.java
@@ -14,7 +14,7 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import org.sosly.villagetale.zone.Zone;
 import org.sosly.villagetale.zone.ZoneRegistry;
 
@@ -87,8 +87,8 @@ public class Box implements IZoneShape {
     }
 
     @Override
-    public ZoneBoundaryPacket createBoundaryPacket(UUID zoneId, UUID villageId) {
-        return new ZoneBoundaryPacket(zoneId, villageId, getID(), bounds);
+    public ZoneBoundary createBoundaryPacket(UUID zoneId, UUID villageId) {
+        return new ZoneBoundary(zoneId, villageId, getID(), bounds);
     }
 
     public static Builder builder(Level level, IVillageCapability village, int ordinal) {

--- a/src/main/java/org/sosly/villagetale/zone/shape/Cylinder.java
+++ b/src/main/java/org/sosly/villagetale/zone/shape/Cylinder.java
@@ -13,7 +13,7 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import org.sosly.villagetale.zone.Zone;
 import org.sosly.villagetale.zone.ZoneRegistry;
 
@@ -115,12 +115,12 @@ public class Cylinder implements IZoneShape {
     }
 
     @Override
-    public ZoneBoundaryPacket createBoundaryPacket(UUID zoneId, UUID villageId) {
+    public ZoneBoundary createBoundaryPacket(UUID zoneId, UUID villageId) {
         AABB bounds = new AABB(
             baseCenter.getX() - radius, baseCenter.getY(), baseCenter.getZ() - radius,
             baseCenter.getX() + radius, baseCenter.getY() + height, baseCenter.getZ() + radius
         );
-        return new ZoneBoundaryPacket(zoneId, villageId, getID(), bounds, baseCenter, radius, height, null);
+        return new ZoneBoundary(zoneId, villageId, getID(), bounds, baseCenter, radius, height, null);
     }
 
     public static Builder builder(Level level, IVillageCapability village, int ordinal) {

--- a/src/main/java/org/sosly/villagetale/zone/shape/Point.java
+++ b/src/main/java/org/sosly/villagetale/zone/shape/Point.java
@@ -13,7 +13,7 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import org.sosly.villagetale.zone.Zone;
 import org.sosly.villagetale.zone.ZoneRegistry;
 
@@ -70,9 +70,9 @@ public class Point implements IZoneShape {
     }
 
     @Override
-    public ZoneBoundaryPacket createBoundaryPacket(UUID zoneId, UUID villageId) {
+    public ZoneBoundary createBoundaryPacket(UUID zoneId, UUID villageId) {
         AABB bounds = new AABB(pos);
-        return new ZoneBoundaryPacket(zoneId, villageId, getID(), bounds);
+        return new ZoneBoundary(zoneId, villageId, getID(), bounds);
     }
 
     public static Builder builder(Level level, IVillageCapability village, int ordinal) {

--- a/src/main/java/org/sosly/villagetale/zone/shape/Route.java
+++ b/src/main/java/org/sosly/villagetale/zone/shape/Route.java
@@ -16,7 +16,7 @@ import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.IZoneShape;
 import org.sosly.villagetale.api.IZoneType;
 import org.sosly.villagetale.api.capability.IVillageCapability;
-import org.sosly.villagetale.network.packets.clientbound.ZoneBoundaryPacket;
+import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import org.sosly.villagetale.zone.Zone;
 import org.sosly.villagetale.zone.ZoneRegistry;
 
@@ -86,7 +86,7 @@ public class Route implements IZoneShape {
     }
 
     @Override
-    public ZoneBoundaryPacket createBoundaryPacket(UUID zoneId, UUID villageId) {
+    public ZoneBoundary createBoundaryPacket(UUID zoneId, UUID villageId) {
         if (points.isEmpty()) {
             return null;
         }
@@ -97,7 +97,7 @@ public class Route implements IZoneShape {
             bounds = bounds.minmax(new AABB(waypoint));
         }
 
-        return new ZoneBoundaryPacket(zoneId, villageId, getID(), bounds, null, 0, 0, points);
+        return new ZoneBoundary(zoneId, villageId, getID(), bounds, null, 0, 0, points);
     }
 
     public static Builder builder(Level level, IVillageCapability village, int ordinal) {

--- a/src/main/resources/assets/villagetale/lang/en_us.json
+++ b/src/main/resources/assets/villagetale/lang/en_us.json
@@ -112,5 +112,13 @@
   "villagetale.gui.townhall.village_name": "Village Name",
   "villagetale.gui.townhall.village_name_label": "Village Name:",
   "villagetale.gui.townhall.save": "Save",
-  "villagetale.gui.townhall.cancel": "Cancel"
+  "villagetale.gui.townhall.cancel": "Cancel",
+
+  "villagetale.gui.conversion.title": "Recruit Villager",
+  "villagetale.gui.conversion.message": "I'd be happy to join your village for %d %s.",
+  "villagetale.gui.conversion.commit": "Recruit",
+  "villagetale.gui.conversion.cancel": "Cancel",
+
+  "villagetale.conversion.insufficient_funds": "Come back when you have what I need!",
+  "villagetale.conversion.success": "Thank you! I look forward to working with you."
 }


### PR DESCRIPTION
# Add villager conversion system
Implements issue #97: right-clicking vanilla villagers with a Ledger opens a GUI to convert them to VillageTale villagers for 10 emeralds. Converted villagers follow the player.

## Changes
- Added AbstractLedgerScreen base class for reusable ledger GUI rendering
- Refactored TownHallScreen to extend AbstractLedgerScreen
- Created VillagerConversionScreen with wrapped text display using item descriptions
- Implemented FollowPlayer brain behavior with 3-block follow distance
- Added FOLLOWING_PLAYER memory module with NBT serialization
- Created VillagerInteractionHandler for ledger/villager interactions (freezes villager during GUI)
- Added OpenVillagerConversionScreen (clientbound) and ConvertVillager (serverbound) packets
- Refactored all packets to use static send() methods with private constructors
- Fixed brain initialization bug where fresh entities had no behaviors registered
- Renamed packet files to remove "Packet" suffix

## Related Issues
Resolves #97

## Implementation Notes
- Conversion GUI displays "I'd be happy to join your village for 10 Emerald" using Items.EMERALD.getDescription()
- Text wraps at GUI_WIDTH - 40 pixels for proper ledger display
- Villagers are frozen during conversion GUI by tracking entity IDs and stopping navigation each tick
- Brain behaviors are now initialized on first customServerAiStep if CORE activity isn't active
- Follow behavior only triggers when player is >3 blocks away to avoid jittery movement
- Packet architecture now uses factory pattern: static send() methods create and send packets

## Breaking Changes
None