### PR TITLE
Add village assignment for following villagers

### DIFF
--- a/src/main/java/org/sosly/villagetale/block/TownHallBlock.java
+++ b/src/main/java/org/sosly/villagetale/block/TownHallBlock.java
@@ -37,6 +37,10 @@ import org.sosly.villagetale.item.LedgerItem;
 import org.sosly.villagetale.network.NetworkHandler;
 import org.sosly.villagetale.network.packets.clientbound.OpenTownHallScreen;
 import org.sosly.villagetale.zone.type.TownHall;
+import org.sosly.villagetale.entity.Villager;
+import net.minecraft.world.phys.AABB;
+
+import java.util.List;
 
 public class TownHallBlock extends Block {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
@@ -66,6 +70,14 @@ public class TownHallBlock extends Block {
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
+    }
+
+    private List<Villager> findFollowerVillagers(ServerLevel level, Player player) {
+        AABB searchArea = player.getBoundingBox().inflate(32.0D);
+        return level.getEntitiesOfClass(Villager.class, searchArea, villager ->
+            villager.getFollowingPlayer().orElse(null) != null &&
+            villager.getFollowingPlayer().get().equals(player.getUUID())
+        );
     }
 
     @Override
@@ -108,6 +120,18 @@ public class TownHallBlock extends Block {
 
         if (!villageCapability.hasPermission(player.getUUID(), IVillageCapability.Permission.OWNER)) {
             player.sendSystemMessage(Component.literal("You do not have permission to manage this village"));
+            return InteractionResult.SUCCESS;
+        }
+
+        List<Villager> followers = findFollowerVillagers(serverLevel, player);
+        if (!followers.isEmpty()) {
+            int assignedCount = 0;
+            for (Villager follower : followers) {
+                follower.setVillage(village.getVillageId());
+                follower.setFollowingPlayer(null);
+                assignedCount++;
+            }
+            player.sendSystemMessage(Component.literal("Assigned " + assignedCount + " villager(s) to " + village.getVillageName()));
             return InteractionResult.SUCCESS;
         }
 


### PR DESCRIPTION
# Add village assignment for following villagers
Implements the ability for players to assign VT:Villagers to a village by right-clicking a Town Hall with a Ledger while having followers nearby.

## Changes
- Added helper method to find all VT:Villagers following a specific player within 32 blocks
- Modified TownHallBlock.use() to check for followers before opening Town Hall GUI
- When followers are present, assigns all followers to the village and stops their following behavior
- When no followers are present, maintains existing behavior of linking Ledger and opening GUI
- Displays confirmation message with count of assigned villagers

## Related Issues
Resolves #98

## Implementation Notes
Uses AABB search with 32-block range to find follower villagers. Assignment automatically handles removing villagers from previous villages and updating village registries through existing setVillage() method. Follow behavior is cleared by setting FOLLOWING_PLAYER memory to null.

## Breaking Changes
None