### PR TITLE
Implement Villager Management GUI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,10 +107,17 @@ This document outlines the development roadmap from Alpha 1 through the 1.0 rele
 
 ### New Features
 
+**Dialogue & Interaction System:**
+- Direct conversation UI for talking to villagers (separate from Ledger)
+- Villagers reveal quests through conversation
+- Access villager inventory by asking them directly
+- Ledger tracks known quests but discovery happens through interaction
+
 **Quest System:**
 - Personal requests from villagers (beds, housing, job changes)
 - Village projects (taverns, decorations, infrastructure improvements)
 - Dynamic quests based on villager needs and happiness
+- Quests discovered through dialogue, tracked in Ledger
 
 **Commerce:**
 - Traveling Merchants visit Town Hall with quests from distant villages

--- a/src/main/java/org/sosly/villagetale/event/VillagerInteractionHandler.java
+++ b/src/main/java/org/sosly/villagetale/event/VillagerInteractionHandler.java
@@ -1,9 +1,10 @@
 package org.sosly.villagetale.event;
 
+import java.util.HashSet;
+import java.util.Set;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.TickEvent;
@@ -11,11 +12,9 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.item.LedgerItem;
 import org.sosly.villagetale.network.packets.clientbound.OpenVillagerConversionScreen;
-
-import java.util.HashSet;
-import java.util.Set;
 
 @Mod.EventBusSubscriber(modid = VillageTale.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class VillagerInteractionHandler {
@@ -23,7 +22,7 @@ public class VillagerInteractionHandler {
 
     @SubscribeEvent
     public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (!(event.getTarget() instanceof Villager villager)) {
+        if (!(event.getTarget() instanceof net.minecraft.world.entity.npc.Villager villager)) {
             return;
         }
 
@@ -58,13 +57,21 @@ public class VillagerInteractionHandler {
         villagersInConversation.removeIf(id -> {
             for (var level : event.getServer().getAllLevels()) {
                 Entity entity = level.getEntity(id);
-                if (entity instanceof Villager villager) {
+                if (entity instanceof Villager vtVillager) {
+                    vtVillager.getNavigation().stop();
+                    return false;
+                }
+                if (entity instanceof net.minecraft.world.entity.npc.Villager villager) {
                     villager.getNavigation().stop();
                     return false;
                 }
             }
             return true;
         });
+    }
+
+    public static void addVillagerToConversation(int villagerId) {
+        villagersInConversation.add(villagerId);
     }
 
     public static void releaseVillager(int villagerId) {

--- a/src/main/java/org/sosly/villagetale/gui/pages/VillagerManagementPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/VillagerManagementPage.java
@@ -1,0 +1,409 @@
+package org.sosly.villagetale.gui.pages;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import org.sosly.villagetale.api.IProfession;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.client.ClientDataManager;
+import org.sosly.villagetale.client.VillageDataManager;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.event.VillagerInteractionHandler;
+import org.sosly.villagetale.gui.LedgerScreen;
+import org.sosly.villagetale.gui.components.LedgerIconButton;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerAssignment;
+import org.sosly.villagetale.profession.ProfessionRegistry;
+import org.sosly.villagetale.zone.type.Home;
+
+public class VillagerManagementPage extends AbstractLedgerPage {
+    private final int villagerEntityId;
+    private final UUID initialHomeZoneId;
+    private final UUID initialWorkZoneId;
+
+    private List<ResourceLocation> professions;
+    private int currentProfessionIndex;
+    private LedgerIconButton professionLeftButton;
+    private LedgerIconButton professionRightButton;
+
+    private List<IVillageZone> homeZones;
+    private int currentHomeZoneIndex;
+    private LedgerIconButton homeZoneLeftButton;
+    private LedgerIconButton homeZoneRightButton;
+
+    private List<IVillageZone> workZones;
+    private int currentWorkZoneIndex;
+    private LedgerIconButton workZoneLeftButton;
+    private LedgerIconButton workZoneRightButton;
+
+    private int selectionStartWidth = 3;
+    private int maxLineLength = 19;
+
+    public VillagerManagementPage(LedgerScreen screen, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId) {
+        super(screen, villageId);
+        this.villagerEntityId = villagerEntityId;
+        this.initialHomeZoneId = homeZoneId;
+        this.initialWorkZoneId = workZoneId;
+        this.professions = new ArrayList<>();
+        this.homeZones = new ArrayList<>();
+        this.workZones = new ArrayList<>();
+    }
+
+    @Override
+    public void attach(int uStart, int vStart) {
+        super.attach(uStart, vStart);
+
+        Villager villager = getVillager();
+        if (villager == null) {
+            return;
+        }
+
+        IVillageCapability village = VillageDataManager.getInstance().getVillageData(villageId);
+        if (village == null) {
+            return;
+        }
+
+        this.professions = new ArrayList<>(ProfessionRegistry.INSTANCE.getProfessionIDs());
+        this.professions.sort((a, b) -> a.getPath().compareTo(b.getPath()));
+
+        ResourceLocation currentProfession = ClientDataManager.getCachedProfession(villagerEntityId);
+        if (currentProfession == null) {
+            currentProfession = ProfessionRegistry.INSTANCE.getProfessionIDs().stream().findFirst().orElse(null);
+        }
+        this.currentProfessionIndex = currentProfession != null ? professions.indexOf(currentProfession) : 0;
+        if (this.currentProfessionIndex < 0) {
+            this.currentProfessionIndex = 0;
+        }
+
+        this.homeZones = village.getZones().stream()
+            .filter(z -> z.getType() != null && z.getType().getID().equals(Home.ID))
+            .sorted((a, b) -> a.getName().compareTo(b.getName()))
+            .toList();
+
+        this.currentHomeZoneIndex = initialHomeZoneId != null
+            ? findZoneIndex(homeZones, initialHomeZoneId)
+            : -1;
+
+        updateWorkZones(villager);
+
+        this.currentWorkZoneIndex = initialWorkZoneId != null
+            ? findZoneIndex(workZones, initialWorkZoneId)
+            : -1;
+
+        initButtons();
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        VillagerInteractionHandler.releaseVillager(villagerEntityId);
+        this.professions = null;
+        this.homeZones = null;
+        this.workZones = null;
+        this.professionLeftButton = null;
+        this.professionRightButton = null;
+        this.homeZoneLeftButton = null;
+        this.homeZoneRightButton = null;
+        this.workZoneLeftButton = null;
+        this.workZoneRightButton = null;
+    }
+
+    private void initButtons() {
+        int currentY = vStart + 16;
+        currentY += LINE_HEIGHT;
+        currentY += LINE_HEIGHT;
+
+        this.professionLeftButton = LedgerIconButton.ArrowLeft(
+            uStart,
+            currentY - 3,
+            button -> cycleProfessionPrevious(),
+            Component.translatable("villagetale.gui.villager_management.profession")
+        );
+        addRenderableWidget(this.professionLeftButton);
+
+        this.professionRightButton = LedgerIconButton.ArrowRight(
+            uStart + LedgerScreen.CONTENT_WIDTH - LedgerIconButton.ARROW_RIGHT.width(),
+            currentY - 3,
+            button -> cycleProfessionNext(),
+            Component.translatable("villagetale.gui.villager_management.profession")
+        );
+        addRenderableWidget(this.professionRightButton);
+
+        currentY += LINE_HEIGHT;
+        currentY += LINE_HEIGHT;
+
+        this.workZoneLeftButton = LedgerIconButton.ArrowLeft(
+            uStart,
+            currentY - 3,
+            button -> cycleWorkZonePrevious(),
+            Component.translatable("villagetale.gui.villager_management.work_zone")
+        );
+        this.workZoneLeftButton.visible = !workZones.isEmpty();
+        addRenderableWidget(this.workZoneLeftButton);
+
+        this.workZoneRightButton = LedgerIconButton.ArrowRight(
+            uStart + LedgerScreen.CONTENT_WIDTH - LedgerIconButton.ARROW_RIGHT.width(),
+            currentY - 3,
+            button -> cycleWorkZoneNext(),
+            Component.translatable("villagetale.gui.villager_management.work_zone")
+        );
+        this.workZoneRightButton.visible = !workZones.isEmpty();
+        addRenderableWidget(this.workZoneRightButton);
+
+        currentY += LINE_HEIGHT;
+        currentY += LINE_HEIGHT;
+
+        this.homeZoneLeftButton = LedgerIconButton.ArrowLeft(
+            uStart,
+            currentY - 3,
+            button -> cycleHomeZonePrevious(),
+            Component.translatable("villagetale.gui.villager_management.home_zone")
+        );
+        this.homeZoneLeftButton.visible = !homeZones.isEmpty();
+        addRenderableWidget(this.homeZoneLeftButton);
+
+        this.homeZoneRightButton = LedgerIconButton.ArrowRight(
+            uStart + LedgerScreen.CONTENT_WIDTH - LedgerIconButton.ARROW_RIGHT.width(),
+            currentY - 3,
+            button -> cycleHomeZoneNext(),
+            Component.translatable("villagetale.gui.villager_management.home_zone")
+        );
+        this.homeZoneRightButton.visible = !homeZones.isEmpty();
+        addRenderableWidget(this.homeZoneRightButton);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        Villager villager = getVillager();
+        if (villager == null) {
+            guiGraphics.drawString(font, Component.literal("Villager not found"), uStart, vStart + 16, 0x3F3F3F, false);
+            return;
+        }
+
+        int currentY = vStart + 16;
+
+        guiGraphics.drawString(font, villager.getDisplayName(), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.translatable("villagetale.gui.villager_management.profession"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        if (!professions.isEmpty() && currentProfessionIndex >= 0 && currentProfessionIndex < professions.size()) {
+            ResourceLocation profession = professions.get(currentProfessionIndex);
+            String professionName = profession.getPath();
+            int professionNameX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
+            guiGraphics.drawString(font, Component.literal(professionName), professionNameX, currentY, 0, false);
+        }
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.translatable("villagetale.gui.villager_management.work_zone"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        if (workZones.isEmpty() || currentWorkZoneIndex < 0) {
+            int noneX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
+            guiGraphics.drawString(font, Component.literal("None"), noneX, currentY, 0x3F3F3F, false);
+        } else if (currentWorkZoneIndex < workZones.size()) {
+            IVillageZone workZone = workZones.get(currentWorkZoneIndex);
+            String zoneName = workZone.getName();
+            if (zoneName.length() > maxLineLength) {
+                zoneName = zoneName.substring(0, maxLineLength - 3) + "...";
+            }
+            int zoneNameX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
+            guiGraphics.drawString(font, Component.literal(zoneName), zoneNameX, currentY, 0, false);
+        }
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.translatable("villagetale.gui.villager_management.home_zone"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        if (homeZones.isEmpty() || currentHomeZoneIndex < 0) {
+            int noneX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
+            guiGraphics.drawString(font, Component.literal("None"), noneX, currentY, 0x3F3F3F, false);
+        } else if (currentHomeZoneIndex < homeZones.size()) {
+            IVillageZone homeZone = homeZones.get(currentHomeZoneIndex);
+            String zoneName = homeZone.getName();
+            if (zoneName.length() > maxLineLength) {
+                zoneName = zoneName.substring(0, maxLineLength - 3) + "...";
+            }
+            int zoneNameX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
+            guiGraphics.drawString(font, Component.literal(zoneName), zoneNameX, currentY, 0, false);
+        }
+    }
+
+    private Villager getVillager() {
+        if (screen.getMinecraft() == null || screen.getMinecraft().level == null) {
+            return null;
+        }
+
+        Entity entity = screen.getMinecraft().level.getEntity(villagerEntityId);
+        if (entity instanceof Villager villager) {
+            return villager;
+        }
+
+        return null;
+    }
+
+    private void updateWorkZones(Villager villager) {
+        IVillageCapability village = VillageDataManager.getInstance().getVillageData(villageId);
+        if (village == null) {
+            this.workZones = new ArrayList<>();
+            return;
+        }
+
+        if (professions.isEmpty() || currentProfessionIndex < 0 || currentProfessionIndex >= professions.size()) {
+            this.workZones = new ArrayList<>();
+            return;
+        }
+
+        ResourceLocation professionId = professions.get(currentProfessionIndex);
+        IProfession profession = ProfessionRegistry.INSTANCE.getProfession(professionId).orElse(null);
+        if (profession == null) {
+            this.workZones = new ArrayList<>();
+            return;
+        }
+
+        this.workZones = village.getZones().stream()
+            .filter(z -> profession.isValidWorkZone(z))
+            .sorted((a, b) -> a.getName().compareTo(b.getName()))
+            .toList();
+    }
+
+    private int findZoneIndex(List<IVillageZone> zones, UUID zoneId) {
+        for (int i = 0; i < zones.size(); i++) {
+            if (zones.get(i).getUUID().equals(zoneId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void cycleProfessionPrevious() {
+        if (professions.isEmpty()) {
+            return;
+        }
+        currentProfessionIndex--;
+        if (currentProfessionIndex < 0) {
+            currentProfessionIndex = professions.size() - 1;
+        }
+        onProfessionChanged();
+    }
+
+    private void cycleProfessionNext() {
+        if (professions.isEmpty()) {
+            return;
+        }
+        currentProfessionIndex++;
+        if (currentProfessionIndex >= professions.size()) {
+            currentProfessionIndex = 0;
+        }
+        onProfessionChanged();
+    }
+
+    private void onProfessionChanged() {
+        if (professions.isEmpty() || currentProfessionIndex < 0 || currentProfessionIndex >= professions.size()) {
+            return;
+        }
+
+        Villager villager = getVillager();
+        if (villager == null) {
+            return;
+        }
+
+        ResourceLocation newProfession = professions.get(currentProfessionIndex);
+        UUID homeZoneId = currentHomeZoneIndex >= 0 && currentHomeZoneIndex < homeZones.size()
+            ? homeZones.get(currentHomeZoneIndex).getUUID()
+            : null;
+
+        updateWorkZones(villager);
+        currentWorkZoneIndex = -1;
+
+        if (this.workZoneLeftButton != null) {
+            this.workZoneLeftButton.visible = !workZones.isEmpty();
+        }
+        if (this.workZoneRightButton != null) {
+            this.workZoneRightButton.visible = !workZones.isEmpty();
+        }
+
+        UpdateVillagerAssignment.send(villagerEntityId, newProfession, homeZoneId, null, true);
+    }
+
+    private void cycleHomeZonePrevious() {
+        if (homeZones.isEmpty()) {
+            return;
+        }
+        currentHomeZoneIndex--;
+        if (currentHomeZoneIndex < 0) {
+            currentHomeZoneIndex = homeZones.size() - 1;
+        }
+        onHomeZoneChanged();
+    }
+
+    private void cycleHomeZoneNext() {
+        if (homeZones.isEmpty()) {
+            return;
+        }
+        currentHomeZoneIndex++;
+        if (currentHomeZoneIndex >= homeZones.size()) {
+            currentHomeZoneIndex = 0;
+        }
+        onHomeZoneChanged();
+    }
+
+    private void onHomeZoneChanged() {
+        if (homeZones.isEmpty() || currentHomeZoneIndex < 0 || currentHomeZoneIndex >= homeZones.size()) {
+            return;
+        }
+
+        ResourceLocation profession = currentProfessionIndex >= 0 && currentProfessionIndex < professions.size()
+            ? professions.get(currentProfessionIndex)
+            : null;
+        UUID homeZoneId = homeZones.get(currentHomeZoneIndex).getUUID();
+        UUID workZoneId = currentWorkZoneIndex >= 0 && currentWorkZoneIndex < workZones.size()
+            ? workZones.get(currentWorkZoneIndex).getUUID()
+            : null;
+
+        UpdateVillagerAssignment.send(villagerEntityId, profession, homeZoneId, workZoneId, false);
+    }
+
+    private void cycleWorkZonePrevious() {
+        if (workZones.isEmpty()) {
+            return;
+        }
+        currentWorkZoneIndex--;
+        if (currentWorkZoneIndex < 0) {
+            currentWorkZoneIndex = workZones.size() - 1;
+        }
+        onWorkZoneChanged();
+    }
+
+    private void cycleWorkZoneNext() {
+        if (workZones.isEmpty()) {
+            return;
+        }
+        currentWorkZoneIndex++;
+        if (currentWorkZoneIndex >= workZones.size()) {
+            currentWorkZoneIndex = 0;
+        }
+        onWorkZoneChanged();
+    }
+
+    private void onWorkZoneChanged() {
+        if (workZones.isEmpty() || currentWorkZoneIndex < 0 || currentWorkZoneIndex >= workZones.size()) {
+            return;
+        }
+
+        ResourceLocation profession = currentProfessionIndex >= 0 && currentProfessionIndex < professions.size()
+            ? professions.get(currentProfessionIndex)
+            : null;
+        UUID homeZoneId = currentHomeZoneIndex >= 0 && currentHomeZoneIndex < homeZones.size()
+            ? homeZones.get(currentHomeZoneIndex).getUUID()
+            : null;
+        UUID workZoneId = workZones.get(currentWorkZoneIndex).getUUID();
+
+        UpdateVillagerAssignment.send(villagerEntityId, profession, homeZoneId, workZoneId, false);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/gui/pages/VillagerStatsPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/VillagerStatsPage.java
@@ -1,0 +1,74 @@
+package org.sosly.villagetale.gui.pages;
+
+import java.util.UUID;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.sosly.villagetale.gui.LedgerScreen;
+
+public class VillagerStatsPage extends AbstractLedgerPage {
+    private static final ResourceLocation GUI_ICONS_LOCATION = new ResourceLocation("textures/gui/icons.png");
+
+    private final int villagerEntityId;
+    private final float health;
+    private final int hunger;
+
+    public VillagerStatsPage(LedgerScreen screen, int villagerEntityId, UUID villageId, float health, int hunger) {
+        super(screen, villageId);
+        this.villagerEntityId = villagerEntityId;
+        this.health = health;
+        this.hunger = hunger;
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        int currentY = vStart + 16;
+
+        guiGraphics.drawString(font, Component.literal("Stats"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.literal("Health:"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+        renderVillagerHearts(guiGraphics, uStart, currentY);
+
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.literal("Hunger:"), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+        renderVillagerHunger(guiGraphics, uStart, currentY);
+    }
+
+    private void renderVillagerHearts(GuiGraphics guiGraphics, int x, int y) {
+        int healthValue = (int) Math.ceil(health);
+        int maxHealth = 20;
+        int hearts = maxHealth / 2;
+
+        for (int i = 0; i < hearts; i++) {
+            int heartX = x + i * 8;
+            int heartIndex = i * 2 + 1;
+
+            guiGraphics.blit(GUI_ICONS_LOCATION, heartX, y, 16, 0, 9, 9);
+
+            if (heartIndex < healthValue) {
+                guiGraphics.blit(GUI_ICONS_LOCATION, heartX, y, 52, 0, 9, 9);
+            } else if (heartIndex == healthValue) {
+                guiGraphics.blit(GUI_ICONS_LOCATION, heartX, y, 61, 0, 9, 9);
+            }
+        }
+    }
+
+    private void renderVillagerHunger(GuiGraphics guiGraphics, int x, int y) {
+        for (int i = 0; i < 10; i++) {
+            int drumstickX = x + i * 8;
+            int hungerIndex = i * 2 + 1;
+
+            guiGraphics.blit(GUI_ICONS_LOCATION, drumstickX, y, 16, 27, 9, 9);
+
+            if (hungerIndex < hunger) {
+                guiGraphics.blit(GUI_ICONS_LOCATION, drumstickX, y, 52, 27, 9, 9);
+            } else if (hungerIndex == hunger) {
+                guiGraphics.blit(GUI_ICONS_LOCATION, drumstickX, y, 61, 27, 9, 9);
+            }
+        }
+    }
+}

--- a/src/main/java/org/sosly/villagetale/item/LedgerItem.java
+++ b/src/main/java/org/sosly/villagetale/item/LedgerItem.java
@@ -1,6 +1,8 @@
 package org.sosly.villagetale.item;
 
-import net.minecraft.core.BlockPos;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -8,6 +10,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -17,13 +20,15 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 import org.sosly.villagetale.api.capability.IVillageCapability;
 import org.sosly.villagetale.api.capability.IVillagesCapability;
-import org.sosly.villagetale.block.TownHallBlock;
 import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.event.VillagerInteractionHandler;
 import org.sosly.villagetale.network.packets.clientbound.OpenVillageInfoScreen;
+import org.sosly.villagetale.network.packets.clientbound.OpenVillagerConversionScreen;
+import org.sosly.villagetale.network.packets.clientbound.OpenVillagerManagementScreen;
 import org.sosly.villagetale.network.packets.clientbound.SyncVillageCapability;
-
-import java.util.UUID;
 
 public class LedgerItem extends Item {
     private static final String VILLAGE_UUID_KEY = "VillageUUID";
@@ -80,10 +85,6 @@ public class LedgerItem extends Item {
             return InteractionResult.SUCCESS;
         }
 
-        if (context.getLevel().getBlockState(context.getClickedPos()).getBlock() instanceof TownHallBlock) {
-            return InteractionResult.PASS;
-        }
-
         if (!(context.getLevel() instanceof ServerLevel serverLevel)) {
             return InteractionResult.FAIL;
         }
@@ -93,6 +94,86 @@ public class LedgerItem extends Item {
         }
 
         return openVillageInfoScreen(context.getItemInHand(), serverLevel, serverPlayer);
+    }
+
+    @Override
+    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity target, InteractionHand hand) {
+        if (player.level().isClientSide) {
+            return InteractionResult.SUCCESS;
+        }
+
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return InteractionResult.FAIL;
+        }
+
+        if (target instanceof net.minecraft.world.entity.npc.Villager vanillaVillager) {
+            vanillaVillager.getNavigation().stop();
+            vanillaVillager.lookAt(player, 180.0F, 180.0F);
+            VillagerInteractionHandler.addVillagerToConversation(target.getId());
+            OpenVillagerConversionScreen.send(serverPlayer, target.getId());
+            return InteractionResult.CONSUME;
+        }
+
+        if (!(target instanceof Villager villager)) {
+            return InteractionResult.PASS;
+        }
+
+        villager.getNavigation().stop();
+        villager.lookAt(player, 180.0F, 180.0F);
+        VillagerInteractionHandler.addVillagerToConversation(target.getId());
+
+        if (villager.getVillage().isEmpty()) {
+            return InteractionResult.FAIL;
+        }
+
+        if (!(player.level() instanceof ServerLevel serverLevel)) {
+            return InteractionResult.FAIL;
+        }
+
+        IVillagesCapability villagesCapability = serverLevel.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+        if (villagesCapability == null) {
+            return InteractionResult.FAIL;
+        }
+
+        VillageInfo village = villagesCapability.getVillageById(villager.getVillage().get());
+        if (village == null) {
+            return InteractionResult.FAIL;
+        }
+
+        ChunkPos villageChunk = village.getVillageStartingChunk();
+        IVillageCapability villageCapability = serverLevel.getChunk(villageChunk.x, villageChunk.z)
+            .getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+
+        if (villageCapability == null) {
+            return InteractionResult.FAIL;
+        }
+
+        UUID homeZoneId = villager.getBrain().getMemory(MemoryModuleTypes.HOME_ZONE.get()).orElse(null);
+        UUID workZoneId = villager.getBrain().getMemory(MemoryModuleTypes.WORK_ZONE.get()).orElse(null);
+
+        List<ItemStack> inventory = new ArrayList<>();
+        for (int i = 0; i < villager.getInventory().getContainerSize(); i++) {
+            inventory.add(villager.getInventory().getItem(i));
+        }
+
+        for (ItemStack equipmentStack : villager.getHandSlots()) {
+            if (!equipmentStack.isEmpty()) {
+                inventory.add(equipmentStack);
+            }
+        }
+
+        for (ItemStack armorStack : villager.getArmorSlots()) {
+            if (!armorStack.isEmpty()) {
+                inventory.add(armorStack);
+            }
+        }
+
+        float health = villager.getHealth();
+        int hunger = villager.getFoodData().getFoodLevel();
+
+        SyncVillageCapability.send(serverPlayer, villageCapability, serverLevel.getServer());
+        OpenVillagerManagementScreen.send(serverPlayer, target.getId(), villager.getVillage().get(), homeZoneId, workZoneId, inventory, health, hunger);
+        return InteractionResult.CONSUME;
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
+++ b/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
@@ -6,6 +6,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.network.packets.clientbound.OpenVillageInfoScreen;
 import org.sosly.villagetale.network.packets.clientbound.OpenVillagerConversionScreen;
+import org.sosly.villagetale.network.packets.clientbound.OpenVillagerManagementScreen;
 import org.sosly.villagetale.network.packets.clientbound.RemoveZoneBoundary;
 import org.sosly.villagetale.network.packets.clientbound.SyncVillageCapability;
 import org.sosly.villagetale.network.packets.clientbound.VillageBoundary;
@@ -17,6 +18,7 @@ import org.sosly.villagetale.network.packets.serverbound.CreateZone;
 import org.sosly.villagetale.network.packets.serverbound.DeleteZone;
 import org.sosly.villagetale.network.packets.serverbound.SetZoneCreationMode;
 import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfo;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerAssignment;
 import org.sosly.villagetale.network.packets.serverbound.UpdateZoneFilters;
 import org.sosly.villagetale.network.packets.serverbound.UpdateZoneName;
 
@@ -75,6 +77,12 @@ public class NetworkHandler {
 
         CHANNEL.registerMessage(packetId++, CreateZone.class,
                 CreateZone::encode, CreateZone::decode, CreateZone::handle);
+
+        CHANNEL.registerMessage(packetId++, OpenVillagerManagementScreen.class,
+                OpenVillagerManagementScreen::encode, OpenVillagerManagementScreen::decode, OpenVillagerManagementScreen::handle);
+
+        CHANNEL.registerMessage(packetId++, UpdateVillagerAssignment.class,
+                UpdateVillagerAssignment::encode, UpdateVillagerAssignment::decode, UpdateVillagerAssignment::handle);
 
         VillageTale.LOGGER.info("VillageTale registered {} network messages", packetId);
     }

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
@@ -1,0 +1,124 @@
+package org.sosly.villagetale.network.packets.clientbound;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.gui.LedgerScreen;
+import org.sosly.villagetale.gui.pages.VillagerManagementPage;
+import org.sosly.villagetale.gui.pages.VillagerStatsPage;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.ClientPacketHandler;
+import org.sosly.villagetale.network.NetworkHandler;
+
+public class OpenVillagerManagementScreen extends BasePacket {
+    private final int villagerEntityId;
+    private final UUID villageId;
+    private final UUID homeZoneId;
+    private final UUID workZoneId;
+    private final List<ItemStack> inventory;
+    private final float health;
+    private final int hunger;
+
+    private OpenVillagerManagementScreen(int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger) {
+        this.villagerEntityId = villagerEntityId;
+        this.villageId = villageId;
+        this.homeZoneId = homeZoneId;
+        this.workZoneId = workZoneId;
+        this.inventory = inventory;
+        this.health = health;
+        this.hunger = hunger;
+    }
+
+    public static void send(ServerPlayer player, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger) {
+        OpenVillagerManagementScreen packet = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger);
+        NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+    }
+
+    public static void encode(OpenVillagerManagementScreen msg, FriendlyByteBuf buffer) {
+        buffer.writeInt(msg.villagerEntityId);
+        buffer.writeUUID(msg.villageId);
+        buffer.writeBoolean(msg.homeZoneId != null);
+        if (msg.homeZoneId != null) {
+            buffer.writeUUID(msg.homeZoneId);
+        }
+        buffer.writeBoolean(msg.workZoneId != null);
+        if (msg.workZoneId != null) {
+            buffer.writeUUID(msg.workZoneId);
+        }
+        buffer.writeInt(msg.inventory.size());
+        for (ItemStack stack : msg.inventory) {
+            buffer.writeItem(stack);
+        }
+        buffer.writeFloat(msg.health);
+        buffer.writeInt(msg.hunger);
+    }
+
+    public static OpenVillagerManagementScreen decode(FriendlyByteBuf buffer) {
+        OpenVillagerManagementScreen msg;
+
+        try {
+            int villagerEntityId = buffer.readInt();
+            UUID villageId = buffer.readUUID();
+            UUID homeZoneId = buffer.readBoolean() ? buffer.readUUID() : null;
+            UUID workZoneId = buffer.readBoolean() ? buffer.readUUID() : null;
+            int inventorySize = buffer.readInt();
+            List<ItemStack> inventory = new ArrayList<>();
+            for (int i = 0; i < inventorySize; i++) {
+                inventory.add(buffer.readItem());
+            }
+            float health = buffer.readFloat();
+            int hunger = buffer.readInt();
+            msg = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading OpenVillagerManagementScreen: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(OpenVillagerManagementScreen msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (!ClientPacketHandler.validateBasics(msg, context)) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            Minecraft mc = Minecraft.getInstance();
+            LedgerScreen screen = new LedgerScreen(Component.translatable("villagetale.gui.villager_management.title"));
+            screen.setLeftPage(new VillagerManagementPage(screen, msg.villagerEntityId, msg.villageId, msg.homeZoneId, msg.workZoneId));
+            screen.setRightPage(new VillagerStatsPage(screen, msg.villagerEntityId, msg.villageId, msg.health, msg.hunger));
+            mc.setScreen(screen);
+        });
+    }
+
+    public int getVillagerEntityId() {
+        return villagerEntityId;
+    }
+
+    public UUID getVillageId() {
+        return villageId;
+    }
+
+    public UUID getHomeZoneId() {
+        return homeZoneId;
+    }
+
+    public UUID getWorkZoneId() {
+        return workZoneId;
+    }
+
+    public List<ItemStack> getInventory() {
+        return inventory;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerAssignment.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerAssignment.java
@@ -1,0 +1,175 @@
+package org.sosly.villagetale.network.packets.serverbound;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.IVillageZone;
+import org.sosly.villagetale.api.capability.IVillageCapability;
+import org.sosly.villagetale.api.capability.IVillagesCapability;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.entity.MemoryModuleTypes;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.NetworkHandler;
+import org.sosly.villagetale.network.ServerPacketHandler;
+import org.sosly.villagetale.profession.ProfessionRegistry;
+
+public class UpdateVillagerAssignment extends BasePacket {
+    private final int villagerEntityId;
+    @Nullable
+    private final ResourceLocation professionId;
+    @Nullable
+    private final UUID homeZoneId;
+    @Nullable
+    private final UUID workZoneId;
+    private final boolean clearWorkZone;
+
+    private UpdateVillagerAssignment(int villagerEntityId, @Nullable ResourceLocation professionId, @Nullable UUID homeZoneId, @Nullable UUID workZoneId, boolean clearWorkZone) {
+        this.villagerEntityId = villagerEntityId;
+        this.professionId = professionId;
+        this.homeZoneId = homeZoneId;
+        this.workZoneId = workZoneId;
+        this.clearWorkZone = clearWorkZone;
+    }
+
+    public static void send(int villagerEntityId, @Nullable ResourceLocation professionId, @Nullable UUID homeZoneId, @Nullable UUID workZoneId, boolean clearWorkZone) {
+        UpdateVillagerAssignment packet = new UpdateVillagerAssignment(villagerEntityId, professionId, homeZoneId, workZoneId, clearWorkZone);
+        NetworkHandler.CHANNEL.sendToServer(packet);
+    }
+
+    public static void encode(UpdateVillagerAssignment msg, FriendlyByteBuf buffer) {
+        buffer.writeInt(msg.villagerEntityId);
+        buffer.writeBoolean(msg.professionId != null);
+        if (msg.professionId != null) {
+            buffer.writeResourceLocation(msg.professionId);
+        }
+        buffer.writeBoolean(msg.homeZoneId != null);
+        if (msg.homeZoneId != null) {
+            buffer.writeUUID(msg.homeZoneId);
+        }
+        buffer.writeBoolean(msg.workZoneId != null);
+        if (msg.workZoneId != null) {
+            buffer.writeUUID(msg.workZoneId);
+        }
+        buffer.writeBoolean(msg.clearWorkZone);
+    }
+
+    public static UpdateVillagerAssignment decode(FriendlyByteBuf buffer) {
+        UpdateVillagerAssignment msg;
+
+        try {
+            int villagerEntityId = buffer.readInt();
+            ResourceLocation professionId = buffer.readBoolean() ? buffer.readResourceLocation() : null;
+            UUID homeZoneId = buffer.readBoolean() ? buffer.readUUID() : null;
+            UUID workZoneId = buffer.readBoolean() ? buffer.readUUID() : null;
+            boolean clearWorkZone = buffer.readBoolean();
+            msg = new UpdateVillagerAssignment(villagerEntityId, professionId, homeZoneId, workZoneId, clearWorkZone);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading UpdateVillagerAssignment: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(UpdateVillagerAssignment msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (!ServerPacketHandler.validateBasics(msg, context)) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            ServerPlayer player = context.getSender();
+            if (player == null) {
+                return;
+            }
+
+            ServerLevel level = player.serverLevel();
+            Entity entity = level.getEntity(msg.villagerEntityId);
+            if (!(entity instanceof Villager villager)) {
+                player.sendSystemMessage(Component.literal("Villager not found"));
+                return;
+            }
+
+            Optional<UUID> villageId = villager.getVillage();
+            if (villageId.isEmpty()) {
+                player.sendSystemMessage(Component.literal("Villager is not assigned to a village"));
+                return;
+            }
+
+            IVillagesCapability villagesCapability = level.getCapability(Capabilities.VILLAGES_CAPABILITY).orElse(null);
+            if (villagesCapability == null) {
+                player.sendSystemMessage(Component.literal("Failed to update villager: capability not found"));
+                return;
+            }
+
+            VillageInfo village = villagesCapability.getVillageById(villageId.get());
+            if (village == null) {
+                player.sendSystemMessage(Component.literal("Village not found"));
+                return;
+            }
+
+            IVillageCapability villageCapability = level.getChunk(village.getVillageStartingChunk().x, village.getVillageStartingChunk().z)
+                .getCapability(Capabilities.VILLAGE_CAPABILITY).orElse(null);
+
+            if (villageCapability == null) {
+                player.sendSystemMessage(Component.literal("Failed to update villager: village capability not found"));
+                return;
+            }
+
+            if (msg.professionId != null) {
+                if (ProfessionRegistry.INSTANCE.getProfession(msg.professionId).isEmpty()) {
+                    player.sendSystemMessage(Component.literal("Invalid profession"));
+                    return;
+                }
+                villager.setProfession(msg.professionId);
+            }
+
+            if (msg.homeZoneId != null) {
+                IVillageZone homeZone = villageCapability.getZones().stream()
+                    .filter(z -> z.getUUID().equals(msg.homeZoneId))
+                    .findFirst()
+                    .orElse(null);
+
+                if (homeZone == null) {
+                    player.sendSystemMessage(Component.literal("Home zone not found"));
+                    return;
+                }
+
+                villager.getBrain().setMemory(MemoryModuleTypes.HOME_ZONE.get(), msg.homeZoneId);
+            }
+
+            if (msg.clearWorkZone) {
+                villager.getBrain().eraseMemory(MemoryModuleTypes.WORK_ZONE.get());
+            } else if (msg.workZoneId != null) {
+                IVillageZone workZone = villageCapability.getZones().stream()
+                    .filter(z -> z.getUUID().equals(msg.workZoneId))
+                    .findFirst()
+                    .orElse(null);
+
+                if (workZone == null) {
+                    player.sendSystemMessage(Component.literal("Work zone not found"));
+                    return;
+                }
+
+                if (!villager.getProfession().isValidWorkZone(workZone)) {
+                    player.sendSystemMessage(Component.literal("Work zone is not valid for this profession"));
+                    return;
+                }
+
+                villager.getBrain().setMemory(MemoryModuleTypes.WORK_ZONE.get(), msg.workZoneId);
+            }
+        });
+    }
+}

--- a/src/main/resources/assets/villagetale/lang/en_us.json
+++ b/src/main/resources/assets/villagetale/lang/en_us.json
@@ -93,6 +93,7 @@
   "villagetale.command.zone.list_filter_error": "Failed to list filter: %s",
 
   "itemGroup.villagetale": "VillageTale",
+  "entity.villagetale.villager": "Villager",
   "profession.villagetale.carpenter": "Carpenter",
   "villagetale.zone.none": "Zone",
   "villagetale.zone.storage": "Storage",
@@ -178,5 +179,11 @@
   "villagetale.gui.new_zone.shape_route_waypoints": "Waypoints: %d",
   "villagetale.gui.new_zone.shape_route_waypoint": "  %d: (%d, %d, %d)",
   "villagetale.gui.new_zone.save": "Save",
-  "villagetale.gui.new_zone.cancel": "Cancel"
+  "villagetale.gui.new_zone.cancel": "Cancel",
+
+  "villagetale.gui.villager_management.title": "Villager Management",
+  "villagetale.gui.villager_management.profession": "Profession:",
+  "villagetale.gui.villager_management.home_zone": "Home Zone:",
+  "villagetale.gui.villager_management.work_zone": "Work Zone:",
+  "villagetale.gui.villager_management.inventory": "Inventory:"
 }


### PR DESCRIPTION
# Implement Villager Management GUI
Adds a GUI that opens when players right-click VT:Villagers with the Ledger, allowing management of profession and zone assignments.

## Changes
- Added VillagerManagementPage with profession, home zone, and work zone selectors
- Added VillagerStatsPage to display villager health and hunger
- Extended LedgerItem to handle VT:Villager interactions
- Added network packets for opening GUI and syncing villager assignments
- Work zone selector filters based on selected profession
- Home zone selector filters to Home-type zones only
- Added villager conversation lock when GUI is open

## Related Issues
Resolves #99

## Implementation Notes
When profession changes, work zone is reset and the dropdown updates to show only zones valid for the new profession. Zone assignments and profession changes send update packets to the server immediately. Villagers are locked in conversation state while GUI is open to prevent them from wandering.

## Breaking Changes
None