### PR TITLE
Add villager recipe management with improved display

### DIFF
--- a/src/main/java/org/sosly/villagetale/api/capability/IRecipeKnowledgeCapability.java
+++ b/src/main/java/org/sosly/villagetale/api/capability/IRecipeKnowledgeCapability.java
@@ -8,4 +8,5 @@ public interface IRecipeKnowledgeCapability {
     public ImmutableSet<ResourceLocation> known();
     public boolean knows(ServerLevel level, ResourceLocation recipeId);
     public boolean learn(ServerLevel level, ResourceLocation recipeId);
+    public boolean forget(ResourceLocation recipeId);
 }

--- a/src/main/java/org/sosly/villagetale/capability/recipeknowledge/RecipeKnowledgeCapability.java
+++ b/src/main/java/org/sosly/villagetale/capability/recipeknowledge/RecipeKnowledgeCapability.java
@@ -47,6 +47,11 @@ public class RecipeKnowledgeCapability implements IRecipeKnowledgeCapability {
         return recipes.add(recipeId);
     }
 
+    @Override
+    public boolean forget(ResourceLocation recipeId) {
+        return recipes.remove(recipeId);
+    }
+
     public void addRecipe(ResourceLocation recipeId) {
         recipes.add(recipeId);
     }

--- a/src/main/java/org/sosly/villagetale/client/ClientDataManager.java
+++ b/src/main/java/org/sosly/villagetale/client/ClientDataManager.java
@@ -5,11 +5,14 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @OnlyIn(Dist.CLIENT)
 public class ClientDataManager {
     private static final Map<Integer, ResourceLocation> professionCache = new HashMap<>();
+    private static final Map<Integer, Set<ResourceLocation>> recipesCache = new HashMap<>();
 
     public static ResourceLocation getCachedProfession(int entityId) {
         return professionCache.get(entityId);
@@ -19,8 +22,17 @@ public class ClientDataManager {
         professionCache.put(entityId, professionId);
     }
 
+    public static Set<ResourceLocation> getCachedRecipes(int entityId) {
+        return recipesCache.get(entityId);
+    }
+
+    public static void cacheRecipes(int entityId, Set<ResourceLocation> recipes) {
+        recipesCache.put(entityId, new HashSet<>(recipes));
+    }
+
     public static void clearAll() {
         professionCache.clear();
+        recipesCache.clear();
         BoundaryDataStorage.getInstance().clearAll();
         VillageDataManager.getInstance().clear();
         ZoneCreationManager.getInstance().cancel();

--- a/src/main/java/org/sosly/villagetale/command/villager/RecipeCommand.java
+++ b/src/main/java/org/sosly/villagetale/command/villager/RecipeCommand.java
@@ -195,21 +195,14 @@ public class RecipeCommand {
         
         if (!knowledge.knows(level, recipeId)) {
             return Result.failure(Component.translatable(
-                    String.format("%s.command.villager.recipes.doesnt_know", VillageTale.MOD_ID), 
+                    String.format("%s.command.villager.recipes.doesnt_know", VillageTale.MOD_ID),
                     villager.getDisplayName().getString(), recipeId));
         }
-        
-        knowledge.known().stream()
-                .filter(id -> id.equals(recipeId))
-                .findFirst()
-                .ifPresent(id -> {
-                    if (knowledge instanceof org.sosly.villagetale.capability.recipeknowledge.RecipeKnowledgeCapability impl) {
-                        impl.getRecipes().remove(id);
-                    }
-                });
-        
+
+        knowledge.forget(recipeId);
+
         return Result.success(Component.translatable(
-                String.format("%s.command.villager.recipes.forgotten", VillageTale.MOD_ID), 
+                String.format("%s.command.villager.recipes.forgotten", VillageTale.MOD_ID),
                 villager.getDisplayName().getString(), recipeId));
     }
 }

--- a/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
@@ -2,17 +2,17 @@ package org.sosly.villagetale.gui.pages;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.ObjectSelectionList;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.item.crafting.Recipe;
 import org.sosly.villagetale.api.IProfession;
 import org.sosly.villagetale.client.ClientDataManager;
 import org.sosly.villagetale.entity.Villager;
@@ -23,7 +23,7 @@ import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerRecipes;
 import org.sosly.villagetale.profession.ProfessionRegistry;
 
 public class RecipeConfigurationPage extends AbstractLedgerPage {
-    private static final int LIST_TOP = 36;
+    private static final int LIST_TOP = 24;
     private static final int LIST_BOTTOM = 145;
 
     private final int villagerEntityId;
@@ -61,19 +61,29 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
             return;
         }
 
-        List<RecipeEntry> entries = new ArrayList<>();
+        Map<String, List<RecipeEntry>> recipesByType = new LinkedHashMap<>();
         Minecraft mc = screen.getMinecraft();
         if (mc != null && mc.level != null) {
             mc.level.getRecipeManager().getRecipes().forEach(recipe -> {
                 if (profession.getLearnableItems().matches(recipe.getResultItem(mc.level.registryAccess()))) {
                     ResourceLocation recipeId = recipe.getId();
-                    String displayName = recipe.getResultItem(mc.level.registryAccess()).getDisplayName().getString();
-                    entries.add(new RecipeEntry(recipeId, displayName));
+                    Component displayName = recipe.getResultItem(mc.level.registryAccess()).getHoverName();
+                    String recipeType = recipe.getType().toString();
+                    String friendlyTypeName = getRecipeTypeName(recipeType);
+
+                    recipesByType.computeIfAbsent(friendlyTypeName, k -> new ArrayList<>())
+                        .add(new RecipeEntry(recipeId, displayName, friendlyTypeName));
                 }
             });
         }
 
-        entries.sort((a, b) -> a.displayName.compareTo(b.displayName));
+        List<String> sortedTypes = new ArrayList<>(recipesByType.keySet());
+        sortedTypes.sort(String::compareTo);
+
+        for (String typeName : sortedTypes) {
+            List<RecipeEntry> recipes = recipesByType.get(typeName);
+            recipes.sort((a, b) -> a.displayName.getString().compareTo(b.displayName.getString()));
+        }
 
         this.recipeList = new RecipeList(
             screen.getMinecraft(),
@@ -82,7 +92,8 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
             vStart + LIST_TOP,
             vStart + LIST_BOTTOM,
             12,
-            entries
+            recipesByType,
+            sortedTypes
         );
         this.recipeList.setLeftPos(uStart);
         addWidget(this.recipeList);
@@ -140,19 +151,72 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
         return null;
     }
 
-    private record RecipeEntry(ResourceLocation id, String displayName) {}
+    private static String getRecipeTypeName(String recipeTypeString) {
+        String cleanType = recipeTypeString;
+        if (cleanType.startsWith("RecipeType[")) {
+            cleanType = cleanType.substring(11, cleanType.length() - 1);
+        }
+
+        if (!cleanType.contains(":")) {
+            return capitalizeWords(cleanType.replace("_", " "));
+        }
+
+        String namespace = cleanType.substring(0, cleanType.indexOf(":"));
+        String path = cleanType.substring(cleanType.indexOf(":") + 1);
+
+        String formattedNamespace = capitalizeWords(namespace);
+        String formattedPath = capitalizeWords(path.replace("_", " "));
+
+        return formattedNamespace + ": " + formattedPath;
+    }
+
+    private static String capitalizeWords(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        String[] words = input.split(" ");
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < words.length; i++) {
+            if (i > 0) {
+                result.append(" ");
+            }
+            String word = words[i];
+            if (!word.isEmpty()) {
+                result.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    result.append(word.substring(1).toLowerCase());
+                }
+            }
+        }
+
+        return result.toString();
+    }
+
+    private record RecipeEntry(ResourceLocation id, Component displayName, String recipeType) {}
 
     private class RecipeList extends ObjectSelectionList<RecipeList.Entry> {
-        private final List<RecipeEntry> recipeEntries;
 
-        public RecipeList(Minecraft minecraft, int width, int height, int y, int bottom, int itemHeight, List<RecipeEntry> entries) {
+        public RecipeList(Minecraft minecraft, int width, int height, int y, int bottom, int itemHeight,
+                          Map<String, List<RecipeEntry>> recipesByType, List<String> sortedTypes) {
             super(minecraft, width, height, y, bottom, itemHeight);
-            this.recipeEntries = entries;
             this.setRenderBackground(false);
             this.setRenderTopAndBottom(false);
             this.setRenderSelection(false);
-            for (RecipeEntry entry : entries) {
-                this.addEntry(new Entry(entry));
+
+            for (int i = 0; i < sortedTypes.size(); i++) {
+                String typeName = sortedTypes.get(i);
+                this.addEntry(new Entry(typeName));
+
+                List<RecipeEntry> recipes = recipesByType.get(typeName);
+                for (RecipeEntry recipe : recipes) {
+                    this.addEntry(new Entry(recipe));
+                }
+
+                if (i < sortedTypes.size() - 1) {
+                    this.addEntry(new Entry());
+                }
             }
         }
 
@@ -168,15 +232,19 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
 
         public class Entry extends ObjectSelectionList.Entry<Entry> {
             private final RecipeEntry recipeEntry;
+            private final String headerText;
+            private final boolean isSpacer;
             private CompactCheckbox checkbox;
 
             public Entry(RecipeEntry recipeEntry) {
                 this.recipeEntry = recipeEntry;
+                this.headerText = null;
+                this.isSpacer = false;
                 this.checkbox = new CompactCheckbox(
                     0,
                     0,
                     LedgerScreen.CONTENT_WIDTH - 10,
-                    Component.literal(recipeEntry.displayName),
+                    recipeEntry.displayName,
                     selectedRecipes.contains(recipeEntry.id)
                 ) {
                     @Override
@@ -187,21 +255,54 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
                 };
             }
 
+            public Entry(String headerText) {
+                this.recipeEntry = null;
+                this.headerText = headerText;
+                this.isSpacer = false;
+                this.checkbox = null;
+            }
+
+            private Entry() {
+                this.recipeEntry = null;
+                this.headerText = null;
+                this.isSpacer = true;
+                this.checkbox = null;
+            }
+
             @Override
             public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
-                this.checkbox.setX(left);
-                this.checkbox.setY(top);
-                this.checkbox.render(guiGraphics, mouseX, mouseY, partialTick);
+                if (isSpacer) {
+                    return;
+                }
+                if (headerText != null) {
+                    guiGraphics.drawString(font, headerText, left, top, 0x3F3F3F, false);
+                } else if (checkbox != null) {
+                    this.checkbox.setX(left);
+                    this.checkbox.setY(top);
+                    this.checkbox.render(guiGraphics, mouseX, mouseY, partialTick);
+                }
             }
 
             @Override
             public boolean mouseClicked(double mouseX, double mouseY, int button) {
-                return this.checkbox.mouseClicked(mouseX, mouseY, button);
+                if (isSpacer) {
+                    return false;
+                }
+                if (checkbox != null) {
+                    return this.checkbox.mouseClicked(mouseX, mouseY, button);
+                }
+                return false;
             }
 
             @Override
             public Component getNarration() {
-                return Component.literal(recipeEntry.displayName);
+                if (isSpacer) {
+                    return Component.empty();
+                }
+                if (headerText != null) {
+                    return Component.literal(headerText);
+                }
+                return recipeEntry.displayName;
             }
 
             private void onCheckboxChanged(boolean checked) {

--- a/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
@@ -1,0 +1,217 @@
+package org.sosly.villagetale.gui.pages;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.crafting.Recipe;
+import org.sosly.villagetale.api.IProfession;
+import org.sosly.villagetale.client.ClientDataManager;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.gui.LedgerScreen;
+import org.sosly.villagetale.gui.components.CompactCheckbox;
+import org.sosly.villagetale.gui.components.LedgerIconButton;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerRecipes;
+import org.sosly.villagetale.profession.ProfessionRegistry;
+
+public class RecipeConfigurationPage extends AbstractLedgerPage {
+    private static final int LIST_TOP = 36;
+    private static final int LIST_BOTTOM = 145;
+
+    private final int villagerEntityId;
+    private RecipeList recipeList;
+    private LedgerIconButton backButton;
+    private Set<ResourceLocation> selectedRecipes;
+
+    public RecipeConfigurationPage(LedgerScreen screen, UUID villageId, int villagerEntityId) {
+        super(screen, villageId);
+        this.villagerEntityId = villagerEntityId;
+        this.selectedRecipes = new HashSet<>();
+    }
+
+    @Override
+    public void attach(int uStart, int vStart) {
+        super.attach(uStart, vStart);
+
+        Set<ResourceLocation> cachedRecipes = ClientDataManager.getCachedRecipes(villagerEntityId);
+        if (cachedRecipes != null) {
+            selectedRecipes.addAll(cachedRecipes);
+        }
+
+        Villager villager = getVillager();
+        if (villager == null) {
+            return;
+        }
+
+        ResourceLocation professionId = ClientDataManager.getCachedProfession(villagerEntityId);
+        if (professionId == null) {
+            return;
+        }
+
+        IProfession profession = ProfessionRegistry.INSTANCE.getProfession(professionId).orElse(null);
+        if (profession == null) {
+            return;
+        }
+
+        List<RecipeEntry> entries = new ArrayList<>();
+        Minecraft mc = screen.getMinecraft();
+        if (mc != null && mc.level != null) {
+            mc.level.getRecipeManager().getRecipes().forEach(recipe -> {
+                if (profession.getLearnableItems().matches(recipe.getResultItem(mc.level.registryAccess()))) {
+                    ResourceLocation recipeId = recipe.getId();
+                    String displayName = recipe.getResultItem(mc.level.registryAccess()).getDisplayName().getString();
+                    entries.add(new RecipeEntry(recipeId, displayName));
+                }
+            });
+        }
+
+        entries.sort((a, b) -> a.displayName.compareTo(b.displayName));
+
+        this.recipeList = new RecipeList(
+            screen.getMinecraft(),
+            LedgerScreen.CONTENT_WIDTH,
+            LIST_BOTTOM - LIST_TOP,
+            vStart + LIST_TOP,
+            vStart + LIST_BOTTOM,
+            12,
+            entries
+        );
+        this.recipeList.setLeftPos(uStart);
+        addWidget(this.recipeList);
+
+        this.backButton = LedgerIconButton.Back(
+            uStart + (LedgerScreen.CONTENT_WIDTH - 14) / 2,
+            vStart + 153,
+            button -> closeRecipes(),
+            Component.translatable("villagetale.gui.back")
+        );
+        addRenderableWidget(this.backButton);
+    }
+
+    @Override
+    public void detach() {
+        super.detach();
+        this.recipeList = null;
+        this.backButton = null;
+        this.selectedRecipes.clear();
+    }
+
+    private void closeRecipes() {
+        Villager villager = getVillager();
+        float health = villager != null ? villager.getHealth() : 0;
+        int hunger = villager != null ? villager.getFoodData().getFoodLevel() : 0;
+
+        screen.setLeftPage(new VillagerManagementPage(screen, villagerEntityId, villageId, null, null));
+        screen.setRightPage(new VillagerStatsPage(screen, villagerEntityId, villageId, health, hunger));
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        Component title = Component.translatable("villagetale.gui.recipe.configure_recipes");
+        guiGraphics.drawString(font, title, uStart, vStart + 16, 0, false);
+
+        if (this.recipeList != null) {
+            this.recipeList.render(guiGraphics, mouseX, mouseY, partialTick);
+        }
+    }
+
+    private void sendRecipeUpdate() {
+        UpdateVillagerRecipes.send(villagerEntityId, new HashSet<>(selectedRecipes));
+    }
+
+    private Villager getVillager() {
+        if (screen.getMinecraft() == null || screen.getMinecraft().level == null) {
+            return null;
+        }
+
+        Entity entity = screen.getMinecraft().level.getEntity(villagerEntityId);
+        if (entity instanceof Villager villager) {
+            return villager;
+        }
+
+        return null;
+    }
+
+    private record RecipeEntry(ResourceLocation id, String displayName) {}
+
+    private class RecipeList extends ObjectSelectionList<RecipeList.Entry> {
+        private final List<RecipeEntry> recipeEntries;
+
+        public RecipeList(Minecraft minecraft, int width, int height, int y, int bottom, int itemHeight, List<RecipeEntry> entries) {
+            super(minecraft, width, height, y, bottom, itemHeight);
+            this.recipeEntries = entries;
+            this.setRenderBackground(false);
+            this.setRenderTopAndBottom(false);
+            this.setRenderSelection(false);
+            for (RecipeEntry entry : entries) {
+                this.addEntry(new Entry(entry));
+            }
+        }
+
+        @Override
+        public int getRowWidth() {
+            return LedgerScreen.CONTENT_WIDTH;
+        }
+
+        @Override
+        protected int getScrollbarPosition() {
+            return this.getRowLeft() + this.getRowWidth() - 6;
+        }
+
+        public class Entry extends ObjectSelectionList.Entry<Entry> {
+            private final RecipeEntry recipeEntry;
+            private CompactCheckbox checkbox;
+
+            public Entry(RecipeEntry recipeEntry) {
+                this.recipeEntry = recipeEntry;
+                this.checkbox = new CompactCheckbox(
+                    0,
+                    0,
+                    LedgerScreen.CONTENT_WIDTH - 10,
+                    Component.literal(recipeEntry.displayName),
+                    selectedRecipes.contains(recipeEntry.id)
+                ) {
+                    @Override
+                    public void onPress() {
+                        super.onPress();
+                        onCheckboxChanged(this.selected());
+                    }
+                };
+            }
+
+            @Override
+            public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+                this.checkbox.setX(left);
+                this.checkbox.setY(top);
+                this.checkbox.render(guiGraphics, mouseX, mouseY, partialTick);
+            }
+
+            @Override
+            public boolean mouseClicked(double mouseX, double mouseY, int button) {
+                return this.checkbox.mouseClicked(mouseX, mouseY, button);
+            }
+
+            @Override
+            public Component getNarration() {
+                return Component.literal(recipeEntry.displayName);
+            }
+
+            private void onCheckboxChanged(boolean checked) {
+                if (checked) {
+                    selectedRecipes.add(recipeEntry.id);
+                } else {
+                    selectedRecipes.remove(recipeEntry.id);
+                }
+                sendRecipeUpdate();
+            }
+        }
+    }
+}

--- a/src/main/java/org/sosly/villagetale/gui/pages/VillagerManagementPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/VillagerManagementPage.java
@@ -2,6 +2,7 @@ package org.sosly.villagetale.gui.pages;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
@@ -39,6 +40,8 @@ public class VillagerManagementPage extends AbstractLedgerPage {
     private int currentWorkZoneIndex;
     private LedgerIconButton workZoneLeftButton;
     private LedgerIconButton workZoneRightButton;
+
+    private LedgerIconButton recipeEditButton;
 
     private int selectionStartWidth = 3;
     private int maxLineLength = 19;
@@ -110,6 +113,7 @@ public class VillagerManagementPage extends AbstractLedgerPage {
         this.homeZoneRightButton = null;
         this.workZoneLeftButton = null;
         this.workZoneRightButton = null;
+        this.recipeEditButton = null;
     }
 
     private void initButtons() {
@@ -174,6 +178,18 @@ public class VillagerManagementPage extends AbstractLedgerPage {
         );
         this.homeZoneRightButton.visible = !homeZones.isEmpty();
         addRenderableWidget(this.homeZoneRightButton);
+
+        currentY += LINE_HEIGHT;
+        currentY += LINE_HEIGHT;
+
+        this.recipeEditButton = LedgerIconButton.Edit(
+            uStart + LedgerScreen.CONTENT_WIDTH - LedgerIconButton.EDIT.width(),
+            currentY - 1,
+            button -> openRecipeConfig(),
+            Component.literal("Edit Recipes")
+        );
+        updateRecipeButtonVisibility();
+        addRenderableWidget(this.recipeEditButton);
     }
 
     @Override
@@ -231,6 +247,21 @@ public class VillagerManagementPage extends AbstractLedgerPage {
             }
             int zoneNameX = uStart + LedgerIconButton.ARROW_LEFT.width() + selectionStartWidth;
             guiGraphics.drawString(font, Component.literal(zoneName), zoneNameX, currentY, 0, false);
+        }
+        currentY += LINE_HEIGHT;
+
+        IProfession profession = currentProfessionIndex >= 0 && currentProfessionIndex < professions.size()
+            ? ProfessionRegistry.INSTANCE.getProfession(professions.get(currentProfessionIndex)).orElse(null)
+            : null;
+
+        if (profession != null && !profession.getLearnableItems().isEmpty()) {
+            guiGraphics.drawString(font, Component.translatable("villagetale.gui.villager_management.recipes"), uStart, currentY, 0, false);
+            currentY += LINE_HEIGHT;
+
+            Set<ResourceLocation> recipes = ClientDataManager.getCachedRecipes(villagerEntityId);
+            int recipeCount = recipes != null ? recipes.size() : 0;
+            String recipeText = "Recipes: " + recipeCount;
+            guiGraphics.drawString(font, Component.literal(recipeText), uStart, currentY, 0, false);
         }
     }
 
@@ -328,7 +359,21 @@ public class VillagerManagementPage extends AbstractLedgerPage {
             this.workZoneRightButton.visible = !workZones.isEmpty();
         }
 
+        updateRecipeButtonVisibility();
+
         UpdateVillagerAssignment.send(villagerEntityId, newProfession, homeZoneId, null, true);
+    }
+
+    private void updateRecipeButtonVisibility() {
+        if (this.recipeEditButton == null) {
+            return;
+        }
+
+        IProfession profession = currentProfessionIndex >= 0 && currentProfessionIndex < professions.size()
+            ? ProfessionRegistry.INSTANCE.getProfession(professions.get(currentProfessionIndex)).orElse(null)
+            : null;
+
+        this.recipeEditButton.visible = profession != null && !profession.getLearnableItems().isEmpty();
     }
 
     private void cycleHomeZonePrevious() {
@@ -405,5 +450,9 @@ public class VillagerManagementPage extends AbstractLedgerPage {
         UUID workZoneId = workZones.get(currentWorkZoneIndex).getUUID();
 
         UpdateVillagerAssignment.send(villagerEntityId, profession, homeZoneId, workZoneId, false);
+    }
+
+    private void openRecipeConfig() {
+        screen.setRightPage(new RecipeConfigurationPage(screen, villageId, villagerEntityId));
     }
 }

--- a/src/main/java/org/sosly/villagetale/item/LedgerItem.java
+++ b/src/main/java/org/sosly/villagetale/item/LedgerItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -171,8 +172,12 @@ public class LedgerItem extends Item {
         float health = villager.getHealth();
         int hunger = villager.getFoodData().getFoodLevel();
 
+        List<ResourceLocation> knownRecipes = villager.getCapability(Capabilities.RECIPE_KNOWLEDGE_CAPABILITY)
+            .map(knowledge -> new ArrayList<>(knowledge.known()))
+            .orElse(new ArrayList<>());
+
         SyncVillageCapability.send(serverPlayer, villageCapability, serverLevel.getServer());
-        OpenVillagerManagementScreen.send(serverPlayer, target.getId(), villager.getVillage().get(), homeZoneId, workZoneId, inventory, health, hunger);
+        OpenVillagerManagementScreen.send(serverPlayer, target.getId(), villager.getVillage().get(), homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
         return InteractionResult.CONSUME;
     }
 

--- a/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
+++ b/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
@@ -19,6 +19,7 @@ import org.sosly.villagetale.network.packets.serverbound.DeleteZone;
 import org.sosly.villagetale.network.packets.serverbound.SetZoneCreationMode;
 import org.sosly.villagetale.network.packets.serverbound.UpdateVillageInfo;
 import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerAssignment;
+import org.sosly.villagetale.network.packets.serverbound.UpdateVillagerRecipes;
 import org.sosly.villagetale.network.packets.serverbound.UpdateZoneFilters;
 import org.sosly.villagetale.network.packets.serverbound.UpdateZoneName;
 
@@ -83,6 +84,9 @@ public class NetworkHandler {
 
         CHANNEL.registerMessage(packetId++, UpdateVillagerAssignment.class,
                 UpdateVillagerAssignment::encode, UpdateVillagerAssignment::decode, UpdateVillagerAssignment::handle);
+
+        CHANNEL.registerMessage(packetId++, UpdateVillagerRecipes.class,
+                UpdateVillagerRecipes::encode, UpdateVillagerRecipes::decode, UpdateVillagerRecipes::handle);
 
         VillageTale.LOGGER.info("VillageTale registered {} network messages", packetId);
     }

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
@@ -1,17 +1,20 @@
 package org.sosly.villagetale.network.packets.clientbound;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.client.ClientDataManager;
 import org.sosly.villagetale.gui.LedgerScreen;
 import org.sosly.villagetale.gui.pages.VillagerManagementPage;
 import org.sosly.villagetale.gui.pages.VillagerStatsPage;
@@ -27,8 +30,9 @@ public class OpenVillagerManagementScreen extends BasePacket {
     private final List<ItemStack> inventory;
     private final float health;
     private final int hunger;
+    private final List<ResourceLocation> knownRecipes;
 
-    private OpenVillagerManagementScreen(int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger) {
+    private OpenVillagerManagementScreen(int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, List<ResourceLocation> knownRecipes) {
         this.villagerEntityId = villagerEntityId;
         this.villageId = villageId;
         this.homeZoneId = homeZoneId;
@@ -36,10 +40,11 @@ public class OpenVillagerManagementScreen extends BasePacket {
         this.inventory = inventory;
         this.health = health;
         this.hunger = hunger;
+        this.knownRecipes = knownRecipes;
     }
 
-    public static void send(ServerPlayer player, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger) {
-        OpenVillagerManagementScreen packet = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger);
+    public static void send(ServerPlayer player, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, List<ResourceLocation> knownRecipes) {
+        OpenVillagerManagementScreen packet = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
         NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
     }
 
@@ -60,6 +65,10 @@ public class OpenVillagerManagementScreen extends BasePacket {
         }
         buffer.writeFloat(msg.health);
         buffer.writeInt(msg.hunger);
+        buffer.writeInt(msg.knownRecipes.size());
+        for (ResourceLocation recipe : msg.knownRecipes) {
+            buffer.writeResourceLocation(recipe);
+        }
     }
 
     public static OpenVillagerManagementScreen decode(FriendlyByteBuf buffer) {
@@ -77,7 +86,12 @@ public class OpenVillagerManagementScreen extends BasePacket {
             }
             float health = buffer.readFloat();
             int hunger = buffer.readInt();
-            msg = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger);
+            int recipeCount = buffer.readInt();
+            List<ResourceLocation> knownRecipes = new ArrayList<>();
+            for (int i = 0; i < recipeCount; i++) {
+                knownRecipes.add(buffer.readResourceLocation());
+            }
+            msg = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
             VillageTale.LOGGER.error("Exception while reading OpenVillagerManagementScreen: {}", err.toString());
             return null;
@@ -94,6 +108,7 @@ public class OpenVillagerManagementScreen extends BasePacket {
         }
 
         context.enqueueWork(() -> {
+            ClientDataManager.cacheRecipes(msg.villagerEntityId, new HashSet<>(msg.knownRecipes));
             Minecraft mc = Minecraft.getInstance();
             LedgerScreen screen = new LedgerScreen(Component.translatable("villagetale.gui.villager_management.title"));
             screen.setLeftPage(new VillagerManagementPage(screen, msg.villagerEntityId, msg.villageId, msg.homeZoneId, msg.workZoneId));

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
@@ -14,7 +14,6 @@ import net.minecraftforge.network.NetworkEvent;
 import org.sosly.villagetale.VillageTale;
 import org.sosly.villagetale.api.capability.IRecipeKnowledgeCapability;
 import org.sosly.villagetale.capability.Capabilities;
-import org.sosly.villagetale.capability.recipeknowledge.RecipeKnowledgeCapability;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.network.BasePacket;
 import org.sosly.villagetale.network.NetworkHandler;
@@ -89,11 +88,6 @@ public class UpdateVillagerRecipes extends BasePacket {
                 return;
             }
 
-            if (!(knowledge instanceof RecipeKnowledgeCapability recipeKnowledge)) {
-                player.sendSystemMessage(Component.literal("Failed to update recipes: invalid capability type"));
-                return;
-            }
-
             Set<ResourceLocation> validatedRecipes = new HashSet<>();
             for (ResourceLocation recipeId : msg.recipes) {
                 Optional<?> recipe = level.getRecipeManager().byKey(recipeId);
@@ -113,8 +107,18 @@ public class UpdateVillagerRecipes extends BasePacket {
                 }
             }
 
-            recipeKnowledge.getRecipes().clear();
-            recipeKnowledge.getRecipes().addAll(validatedRecipes);
+            Set<ResourceLocation> currentRecipes = knowledge.known();
+            for (ResourceLocation recipeId : currentRecipes) {
+                if (!validatedRecipes.contains(recipeId)) {
+                    knowledge.forget(recipeId);
+                }
+            }
+
+            for (ResourceLocation recipeId : validatedRecipes) {
+                if (!currentRecipes.contains(recipeId)) {
+                    knowledge.learn(level, recipeId);
+                }
+            }
         });
     }
 }

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
@@ -1,0 +1,120 @@
+package org.sosly.villagetale.network.packets.serverbound;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.api.capability.IRecipeKnowledgeCapability;
+import org.sosly.villagetale.capability.Capabilities;
+import org.sosly.villagetale.capability.recipeknowledge.RecipeKnowledgeCapability;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.NetworkHandler;
+import org.sosly.villagetale.network.ServerPacketHandler;
+
+public class UpdateVillagerRecipes extends BasePacket {
+    private final int villagerEntityId;
+    private final Set<ResourceLocation> recipes;
+
+    private UpdateVillagerRecipes(int villagerEntityId, Set<ResourceLocation> recipes) {
+        this.villagerEntityId = villagerEntityId;
+        this.recipes = recipes;
+    }
+
+    public static void send(int villagerEntityId, Set<ResourceLocation> recipes) {
+        UpdateVillagerRecipes packet = new UpdateVillagerRecipes(villagerEntityId, recipes);
+        NetworkHandler.CHANNEL.sendToServer(packet);
+    }
+
+    public static void encode(UpdateVillagerRecipes msg, FriendlyByteBuf buffer) {
+        buffer.writeInt(msg.villagerEntityId);
+        buffer.writeInt(msg.recipes.size());
+        for (ResourceLocation recipe : msg.recipes) {
+            buffer.writeResourceLocation(recipe);
+        }
+    }
+
+    public static UpdateVillagerRecipes decode(FriendlyByteBuf buffer) {
+        UpdateVillagerRecipes msg;
+
+        try {
+            int villagerEntityId = buffer.readInt();
+            int recipeCount = buffer.readInt();
+            Set<ResourceLocation> recipes = new HashSet<>();
+            for (int i = 0; i < recipeCount; i++) {
+                recipes.add(buffer.readResourceLocation());
+            }
+            msg = new UpdateVillagerRecipes(villagerEntityId, recipes);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading UpdateVillagerRecipes: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(UpdateVillagerRecipes msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (!ServerPacketHandler.validateBasics(msg, context)) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            ServerPlayer player = context.getSender();
+            if (player == null) {
+                return;
+            }
+
+            ServerLevel level = player.serverLevel();
+            Entity entity = level.getEntity(msg.villagerEntityId);
+            if (!(entity instanceof Villager villager)) {
+                player.sendSystemMessage(Component.literal("Villager not found"));
+                return;
+            }
+
+            IRecipeKnowledgeCapability knowledge = villager.getCapability(Capabilities.RECIPE_KNOWLEDGE_CAPABILITY)
+                .orElse(null);
+
+            if (knowledge == null) {
+                player.sendSystemMessage(Component.literal("Failed to update recipes: capability not found"));
+                return;
+            }
+
+            if (!(knowledge instanceof RecipeKnowledgeCapability recipeKnowledge)) {
+                player.sendSystemMessage(Component.literal("Failed to update recipes: invalid capability type"));
+                return;
+            }
+
+            Set<ResourceLocation> validatedRecipes = new HashSet<>();
+            for (ResourceLocation recipeId : msg.recipes) {
+                Optional<?> recipe = level.getRecipeManager().byKey(recipeId);
+                if (recipe.isEmpty()) {
+                    continue;
+                }
+
+                if (villager.getProfession() != null) {
+                    if (villager.getProfession().getLearnableItems().isEmpty() ||
+                        villager.getProfession().getLearnableItems().matches(
+                            level.getRecipeManager().byKey(recipeId)
+                                .map(r -> r.getResultItem(level.registryAccess()))
+                                .orElse(net.minecraft.world.item.ItemStack.EMPTY)
+                        )) {
+                        validatedRecipes.add(recipeId);
+                    }
+                }
+            }
+
+            recipeKnowledge.getRecipes().clear();
+            recipeKnowledge.getRecipes().addAll(validatedRecipes);
+        });
+    }
+}

--- a/src/main/resources/assets/villagetale/lang/de_de.json
+++ b/src/main/resources/assets/villagetale/lang/de_de.json
@@ -185,5 +185,10 @@
   "villagetale.gui.villager_management.profession": "Beruf:",
   "villagetale.gui.villager_management.home_zone": "Wohnzone:",
   "villagetale.gui.villager_management.work_zone": "Arbeitszone:",
-  "villagetale.gui.villager_management.inventory": "Inventar:"
+  "villagetale.gui.villager_management.recipes": "Rezepte:",
+  "villagetale.gui.villager_management.inventory": "Inventar:",
+
+  "villagetale.gui.recipe.configure_recipes": "Dörfler-Rezepte",
+
+  "villagetale.gui.back": "Zurück"
 }

--- a/src/main/resources/assets/villagetale/lang/en_us.json
+++ b/src/main/resources/assets/villagetale/lang/en_us.json
@@ -185,5 +185,10 @@
   "villagetale.gui.villager_management.profession": "Profession:",
   "villagetale.gui.villager_management.home_zone": "Home Zone:",
   "villagetale.gui.villager_management.work_zone": "Work Zone:",
-  "villagetale.gui.villager_management.inventory": "Inventory:"
+  "villagetale.gui.villager_management.recipes": "Recipes:",
+  "villagetale.gui.villager_management.inventory": "Inventory:",
+
+  "villagetale.gui.recipe.configure_recipes": "Villager Recipes",
+
+  "villagetale.gui.back": "Back"
 }


### PR DESCRIPTION
# Add villager recipe management with improved display
Implements recipe knowledge tracking for villagers with a GUI for managing which recipes they know. Recipes are grouped by type and displayed with proper formatting to differentiate between multiple recipes for the same item.

## Changes
- Added recipe configuration page to villager management GUI
- Implemented recipe grouping by type (Furnace, Smoker, Campfire, etc.)
- Fixed display to show proper item names without brackets
- Added visual spacing between recipe type groups
- Dynamic formatting supports modded recipe types without hardcoding

## Related Issues
Resolves #99

## Implementation Notes
Recipe types are extracted from `recipe.getType().toString()` and formatted dynamically, so any modded recipe types (like Create's milling or Thermal's smelter) will display properly without needing special handling. Item display names use `getHoverName()` and remain as Components throughout to avoid the bracket formatting issue.

## Breaking Changes
None