### PR TITLE
Fix recipe persistence and ingredient gathering

### DIFF
--- a/src/main/java/org/sosly/villagetale/entity/ai/behavior/CraftRecipeItem.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/behavior/CraftRecipeItem.java
@@ -80,6 +80,12 @@ public class CraftRecipeItem extends Behavior<Villager> {
         this.workstation = pos;
         this.workplace = zone;
         this.craftingMethod = RecipeManager.getInstance().getCraftingMethod(recipe);
+
+        SimpleContainer inventory = villager.getInventory();
+        if (!hasAllIngredients(inventory)) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasResources.java
+++ b/src/main/java/org/sosly/villagetale/entity/ai/sensor/HasResources.java
@@ -1,16 +1,22 @@
 package org.sosly.villagetale.entity.ai.sensor;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
 import org.sosly.villagetale.api.IWantedItem;
+import org.sosly.villagetale.data.WantedItem;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.helper.ItemMatcher;
+import org.sosly.villagetale.helper.VillagerHelper;
 
 public class HasResources extends Sensor<Villager> {
 

--- a/src/main/java/org/sosly/villagetale/helper/ItemMatcher.java
+++ b/src/main/java/org/sosly/villagetale/helper/ItemMatcher.java
@@ -1,9 +1,12 @@
 package org.sosly.villagetale.helper;
 
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import org.sosly.villagetale.api.IVillageZone;
 import org.sosly.villagetale.api.IWantedItem;
@@ -11,7 +14,12 @@ import org.sosly.villagetale.data.WantedItem;
 import org.sosly.villagetale.entity.MemoryModuleTypes;
 import org.sosly.villagetale.entity.Villager;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public enum ItemMatcher {
     PROFESSION_TOOL {
@@ -90,16 +98,61 @@ public enum ItemMatcher {
                 return List.of();
             }
 
-            int ingredientCount = (int) recipe.getIngredients().stream()
-                    .filter(ingredient -> !ingredient.isEmpty())
-                    .count();
+            Map<String, Pair<Ingredient, Integer>> ingredientMap = new HashMap<>();
 
-            int minimum = Math.max(0, ingredientCount - 1);
-            int target = Math.max(ingredientCount * 3, 9);
+            for (Ingredient ingredient : recipe.getIngredients()) {
+                if (ingredient.isEmpty()) {
+                    continue;
+                }
 
-            return List.of(new WantedItem((item) -> recipe.getIngredients()
-                    .stream()
-                    .anyMatch(ingredient -> ingredient.test(item)), target, minimum));
+                ItemStack[] items = ingredient.getItems();
+                if (items.length == 0) {
+                    continue;
+                }
+
+                String key = Arrays.stream(items)
+                        .map(stack -> stack.getItem().toString())
+                        .sorted()
+                        .collect(Collectors.joining(","));
+
+                if (key.isEmpty()) {
+                    continue;
+                }
+
+                if (ingredientMap.containsKey(key)) {
+                    Pair<Ingredient, Integer> pair = ingredientMap.get(key);
+                    ingredientMap.put(key, Pair.of(pair.getFirst(), pair.getSecond() + 1));
+                } else {
+                    ingredientMap.put(key, Pair.of(ingredient, 1));
+                }
+            }
+
+            List<IWantedItem> wantedItems = new ArrayList<>();
+            SimpleContainer inventory = villager.getInventory();
+
+            for (Pair<Ingredient, Integer> pair : ingredientMap.values()) {
+                Ingredient ingredient = pair.getFirst();
+                int neededCount = pair.getSecond();
+
+                int inventoryCount = countIngredientInInventory(inventory, ingredient);
+
+                if (inventoryCount < neededCount) {
+                    wantedItems.add(new WantedItem(ingredient::test, neededCount, 0));
+                }
+            }
+
+            return wantedItems;
+        }
+
+        private int countIngredientInInventory(SimpleContainer inventory, Ingredient ingredient) {
+            int count = 0;
+            for (int i = 0; i < inventory.getContainerSize(); i++) {
+                ItemStack stack = inventory.getItem(i);
+                if (!stack.isEmpty() && ingredient.test(stack)) {
+                    count += stack.getCount();
+                }
+            }
+            return count;
         }
     };
 

--- a/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
+++ b/src/main/java/org/sosly/villagetale/network/NetworkHandler.java
@@ -12,6 +12,7 @@ import org.sosly.villagetale.network.packets.clientbound.SyncVillageCapability;
 import org.sosly.villagetale.network.packets.clientbound.VillageBoundary;
 import org.sosly.villagetale.network.packets.clientbound.VillagerEquipmentSync;
 import org.sosly.villagetale.network.packets.clientbound.VillagerProfessionSync;
+import org.sosly.villagetale.network.packets.clientbound.VillagerRecipesSync;
 import org.sosly.villagetale.network.packets.clientbound.ZoneBoundary;
 import org.sosly.villagetale.network.packets.serverbound.ConvertVillager;
 import org.sosly.villagetale.network.packets.serverbound.CreateZone;
@@ -39,6 +40,9 @@ public class NetworkHandler {
         CHANNEL.registerMessage(packetId++, VillagerEquipmentSync.class,
                 VillagerEquipmentSync::encode, VillagerEquipmentSync::decode, VillagerEquipmentSync::handle
         );
+
+        CHANNEL.registerMessage(packetId++, VillagerRecipesSync.class,
+                VillagerRecipesSync::encode, VillagerRecipesSync::decode, VillagerRecipesSync::handle);
 
         CHANNEL.registerMessage(packetId++, VillageBoundary.class,
                 VillageBoundary::encode, VillageBoundary::decode, VillageBoundary::handle);

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerRecipesSync.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/VillagerRecipesSync.java
@@ -1,0 +1,91 @@
+package org.sosly.villagetale.network.packets.clientbound;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+import org.sosly.villagetale.VillageTale;
+import org.sosly.villagetale.client.ClientDataManager;
+import org.sosly.villagetale.entity.Villager;
+import org.sosly.villagetale.network.BasePacket;
+import org.sosly.villagetale.network.ClientPacketHandler;
+import org.sosly.villagetale.network.NetworkHandler;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class VillagerRecipesSync extends BasePacket {
+    private final int entityId;
+    private final Set<ResourceLocation> recipes;
+
+    private VillagerRecipesSync(int entityId, Set<ResourceLocation> recipes) {
+        this.entityId = entityId;
+        this.recipes = recipes;
+    }
+
+    public static void sendToPlayer(Villager villager, Set<ResourceLocation> recipes, ServerPlayer player) {
+        VillagerRecipesSync packet = new VillagerRecipesSync(villager.getId(), recipes);
+        NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+    }
+
+    public static void encode(VillagerRecipesSync msg, FriendlyByteBuf buffer) {
+        buffer.writeVarInt(msg.entityId);
+        buffer.writeInt(msg.recipes.size());
+        for (ResourceLocation recipe : msg.recipes) {
+            buffer.writeResourceLocation(recipe);
+        }
+    }
+
+    public static VillagerRecipesSync decode(FriendlyByteBuf buffer) {
+        VillagerRecipesSync msg;
+
+        try {
+            int entityId = buffer.readVarInt();
+            int recipeCount = buffer.readInt();
+            Set<ResourceLocation> recipes = new HashSet<>();
+            for (int i = 0; i < recipeCount; i++) {
+                recipes.add(buffer.readResourceLocation());
+            }
+            msg = new VillagerRecipesSync(entityId, recipes);
+        } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
+            VillageTale.LOGGER.error("Exception while reading VillagerRecipesSync: {}", err.toString());
+            return null;
+        }
+
+        msg.messageIsValid = true;
+        return msg;
+    }
+
+    public static void handle(VillagerRecipesSync msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (ClientPacketHandler.validateBasics(msg, context)) {
+            context.enqueueWork(() -> {
+                Minecraft mc = Minecraft.getInstance();
+                if (mc.level == null) {
+                    return;
+                }
+
+                Entity entity = mc.level.getEntity(msg.entityId);
+                if (entity != null) {
+                    ClientDataManager.cacheRecipes(msg.entityId, msg.recipes);
+                }
+            }).whenComplete((r, e) -> {
+                if (e != null) {
+                    throw new RuntimeException("Failed to handle VillagerRecipesSync", e);
+                }
+            });
+        }
+    }
+
+    public int getEntityId() {
+        return entityId;
+    }
+
+    public Set<ResourceLocation> getRecipes() {
+        return recipes;
+    }
+}

--- a/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/serverbound/UpdateVillagerRecipes.java
@@ -18,6 +18,7 @@ import org.sosly.villagetale.entity.Villager;
 import org.sosly.villagetale.network.BasePacket;
 import org.sosly.villagetale.network.NetworkHandler;
 import org.sosly.villagetale.network.ServerPacketHandler;
+import org.sosly.villagetale.network.packets.clientbound.VillagerRecipesSync;
 
 public class UpdateVillagerRecipes extends BasePacket {
     private final int villagerEntityId;
@@ -119,6 +120,8 @@ public class UpdateVillagerRecipes extends BasePacket {
                     knowledge.learn(level, recipeId);
                 }
             }
+
+            VillagerRecipesSync.sendToPlayer(villager, new HashSet<>(knowledge.known()), player);
         });
     }
 }


### PR DESCRIPTION
# Fix recipe persistence and ingredient gathering
Resolves three critical issues preventing villagers from properly managing and executing crafting recipes.

## Changes
- Created VillagerRecipesSync packet to sync validated recipes from server to client cache
- Added ingredient check to CraftRecipeItem.checkExtraStartConditions() to prevent workstation claiming without materials
- Rewrote ItemMatcher.RESOURCES.getProfessionDefault() to track each ingredient type separately with accurate counts
- Added helper method countIngredientInInventory() for per-ingredient inventory checking

## Related Issues
Resolves #128

## Implementation Notes
**Recipe Persistence**: The original issue was that client cache never updated after sending UpdateVillagerRecipes. Now the server sends VillagerRecipesSync back with the validated recipe set, keeping client and server in sync.

**Villager Stuck Behavior**: Villagers would claim workstations for 200 ticks even when missing ingredients, doing nothing. Now they check for ingredients before claiming, allowing them to move to other tasks.

**Ingredient Gathering**: The critical bug was in ItemMatcher.RESOURCES which created one WantedItem matching ANY ingredient using anyMatch(). For a recipe needing 3 planks + 2 sticks, if the villager had 9 planks, it would count 9 items matching (planks OR sticks) and never request sticks. Now it groups ingredients by type, counts each separately, and returns a List with one WantedItem per missing ingredient with accurate counts.

## Breaking Changes
None