### PR TITLE
feat: add villager stats system (Physique, Intellect, Endurance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/SoSly/VillageTale)
 
+### Added
+- Villagers now have three core stats (Physique, Intellect, Endurance) visible in the villager management screen
+
 ### Changed
 - Recipe knowledge storage format updated (legacy saves will migrate automatically)
 

--- a/src/main/java/org/sosly/villagetale/data/VillagerStats.java
+++ b/src/main/java/org/sosly/villagetale/data/VillagerStats.java
@@ -1,0 +1,49 @@
+package org.sosly.villagetale.data;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.RandomSource;
+
+public class VillagerStats {
+    private int physique;
+    private int endurance;
+    private int intellect;
+
+    public VillagerStats() {
+        this.physique = 0;
+        this.endurance = 0;
+        this.intellect = 0;
+    }
+
+    public int getPhysique() {
+        return physique;
+    }
+
+    public int getEndurance() {
+        return endurance;
+    }
+
+    public int getIntellect() {
+        return intellect;
+    }
+
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt("Physique", physique);
+        tag.putInt("Endurance", endurance);
+        tag.putInt("Intellect", intellect);
+        return tag;
+    }
+
+    public void deserializeInto(CompoundTag nbt, RandomSource random) {
+        if (nbt.contains("Physique") && nbt.contains("Endurance") && nbt.contains("Intellect")) {
+            this.physique = nbt.getInt("Physique");
+            this.endurance = nbt.getInt("Endurance");
+            this.intellect = nbt.getInt("Intellect");
+            return;
+        }
+
+        this.physique = 1 + random.nextInt(4);
+        this.endurance = 1 + random.nextInt(4);
+        this.intellect = 1 + random.nextInt(4);
+    }
+}

--- a/src/main/java/org/sosly/villagetale/data/VillagerStats.java
+++ b/src/main/java/org/sosly/villagetale/data/VillagerStats.java
@@ -14,9 +14,9 @@ public class VillagerStats {
     private int intellect;
 
     public VillagerStats() {
-        this.physique = 0;
-        this.endurance = 0;
-        this.intellect = 0;
+        this.physique = MIN_STAT_VALUE;
+        this.endurance = MIN_STAT_VALUE;
+        this.intellect = MIN_STAT_VALUE;
     }
 
     public int getPhysique() {

--- a/src/main/java/org/sosly/villagetale/data/VillagerStats.java
+++ b/src/main/java/org/sosly/villagetale/data/VillagerStats.java
@@ -1,9 +1,14 @@
 package org.sosly.villagetale.data;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 
 public class VillagerStats {
+    private static final int MIN_STAT_VALUE = 1;
+    private static final int MAX_STARTING_STAT_VALUE = 4;
+    private static final int MAX_STAT_VALUE = 20;
+
     private int physique;
     private int endurance;
     private int intellect;
@@ -18,12 +23,24 @@ public class VillagerStats {
         return physique;
     }
 
+    public void setPhysique(int physique) {
+        this.physique = Mth.clamp(physique, MIN_STAT_VALUE, MAX_STAT_VALUE);
+    }
+
     public int getEndurance() {
         return endurance;
     }
 
+    public void setEndurance(int endurance) {
+        this.endurance = Mth.clamp(endurance, MIN_STAT_VALUE, MAX_STAT_VALUE);
+    }
+
     public int getIntellect() {
         return intellect;
+    }
+
+    public void setIntellect(int intellect) {
+        this.intellect = Mth.clamp(intellect, MIN_STAT_VALUE, MAX_STAT_VALUE);
     }
 
     public CompoundTag serializeNBT() {
@@ -34,16 +51,16 @@ public class VillagerStats {
         return tag;
     }
 
-    public void deserializeInto(CompoundTag nbt, RandomSource random) {
-        if (nbt.contains("Physique") && nbt.contains("Endurance") && nbt.contains("Intellect")) {
-            this.physique = nbt.getInt("Physique");
-            this.endurance = nbt.getInt("Endurance");
-            this.intellect = nbt.getInt("Intellect");
+    public void deserializeNBT(CompoundTag nbt, RandomSource random) {
+        if (!nbt.contains("Physique") || !nbt.contains("Endurance") || !nbt.contains("Intellect")) {
+            this.physique = MIN_STAT_VALUE + random.nextInt(MAX_STARTING_STAT_VALUE);
+            this.endurance = MIN_STAT_VALUE + random.nextInt(MAX_STARTING_STAT_VALUE);
+            this.intellect = MIN_STAT_VALUE + random.nextInt(MAX_STARTING_STAT_VALUE);
             return;
         }
 
-        this.physique = 1 + random.nextInt(4);
-        this.endurance = 1 + random.nextInt(4);
-        this.intellect = 1 + random.nextInt(4);
+        this.physique = Mth.clamp(nbt.getInt("Physique"), MIN_STAT_VALUE, MAX_STAT_VALUE);
+        this.endurance = Mth.clamp(nbt.getInt("Endurance"), MIN_STAT_VALUE, MAX_STAT_VALUE);
+        this.intellect = Mth.clamp(nbt.getInt("Intellect"), MIN_STAT_VALUE, MAX_STAT_VALUE);
     }
 }

--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -348,9 +348,9 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         }
 
         if (tag.contains("Stats")) {
-            this.stats.deserializeInto(tag.getCompound("Stats"), this.random);
+            this.stats.deserializeNBT(tag.getCompound("Stats"), this.random);
         } else {
-            this.stats.deserializeInto(new CompoundTag(), this.random);
+            this.stats.deserializeNBT(new CompoundTag(), this.random);
         }
 
         if (this.level() instanceof ServerLevel serverLevel) {

--- a/src/main/java/org/sosly/villagetale/entity/Villager.java
+++ b/src/main/java/org/sosly/villagetale/entity/Villager.java
@@ -64,6 +64,7 @@ import org.sosly.villagetale.capability.Capabilities;
 import org.sosly.villagetale.data.LivingEntityFoodData;
 import org.sosly.villagetale.data.RecipeKnowledge;
 import org.sosly.villagetale.data.VillageInfo;
+import org.sosly.villagetale.data.VillagerStats;
 import org.sosly.villagetale.entity.ai.SensorTypes;
 import org.sosly.villagetale.entity.ai.goals.VillagerGoalPackages;
 import org.sosly.villagetale.entity.ai.navigation.VillagerGroundPathNavigation;
@@ -80,6 +81,7 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
     private final LivingEntityFoodData foodData;
     private final SimpleContainer inventory;
     private final RecipeKnowledge recipeKnowledge;
+    private final VillagerStats stats;
     private ImmutableList<MemoryModuleType<?>> memoryTypes;
 
     private ImmutableList<SensorType<? extends Sensor<? super Villager>>> sensorTypes;
@@ -101,6 +103,7 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         this.foodData = new LivingEntityFoodData();
         this.inventory = new SimpleContainer(5);
         this.recipeKnowledge = new RecipeKnowledge();
+        this.stats = new VillagerStats();
         ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
         this.getNavigation().setCanFloat(true);
         this.setCanPickUpLoot(true);
@@ -241,6 +244,10 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         return this.recipeKnowledge;
     }
 
+    public VillagerStats getStats() {
+        return this.stats;
+    }
+
     @Override
     public void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
@@ -285,6 +292,7 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
         }
 
         tag.put("RecipeKnowledge", this.recipeKnowledge.serializeNBT());
+        tag.put("Stats", this.stats.serializeNBT());
     }
 
     @Override
@@ -337,6 +345,12 @@ public class Villager extends PathfinderMob implements InventoryCarrier {
             this.recipeKnowledge.deserializeInto(tag.getCompound("RecipeKnowledge"));
         } else if (tag.contains("forge:recipe_knowledge")) {
             this.recipeKnowledge.deserializeInto(tag.getCompound("forge:recipe_knowledge"));
+        }
+
+        if (tag.contains("Stats")) {
+            this.stats.deserializeInto(tag.getCompound("Stats"), this.random);
+        } else {
+            this.stats.deserializeInto(new CompoundTag(), this.random);
         }
 
         if (this.level() instanceof ServerLevel serverLevel) {

--- a/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/RecipeConfigurationPage.java
@@ -119,9 +119,12 @@ public class RecipeConfigurationPage extends AbstractLedgerPage {
         Villager villager = getVillager();
         float health = villager != null ? villager.getHealth() : 0;
         int hunger = villager != null ? villager.getFoodData().getFoodLevel() : 0;
+        int physique = villager != null ? villager.getStats().getPhysique() : 0;
+        int endurance = villager != null ? villager.getStats().getEndurance() : 0;
+        int intellect = villager != null ? villager.getStats().getIntellect() : 0;
 
         screen.setLeftPage(new VillagerManagementPage(screen, villagerEntityId, villageId, null, null));
-        screen.setRightPage(new VillagerStatsPage(screen, villagerEntityId, villageId, health, hunger));
+        screen.setRightPage(new VillagerStatsPage(screen, villagerEntityId, villageId, health, hunger, physique, endurance, intellect));
     }
 
     @Override

--- a/src/main/java/org/sosly/villagetale/gui/pages/VillagerStatsPage.java
+++ b/src/main/java/org/sosly/villagetale/gui/pages/VillagerStatsPage.java
@@ -12,12 +12,18 @@ public class VillagerStatsPage extends AbstractLedgerPage {
     private final int villagerEntityId;
     private final float health;
     private final int hunger;
+    private final int physique;
+    private final int endurance;
+    private final int intellect;
 
-    public VillagerStatsPage(LedgerScreen screen, int villagerEntityId, UUID villageId, float health, int hunger) {
+    public VillagerStatsPage(LedgerScreen screen, int villagerEntityId, UUID villageId, float health, int hunger, int physique, int endurance, int intellect) {
         super(screen, villageId);
         this.villagerEntityId = villagerEntityId;
         this.health = health;
         this.hunger = hunger;
+        this.physique = physique;
+        this.endurance = endurance;
+        this.intellect = intellect;
     }
 
     @Override
@@ -36,6 +42,16 @@ public class VillagerStatsPage extends AbstractLedgerPage {
         guiGraphics.drawString(font, Component.literal("Hunger:"), uStart, currentY, 0, false);
         currentY += LINE_HEIGHT;
         renderVillagerHunger(guiGraphics, uStart, currentY);
+
+        currentY += LINE_HEIGHT * 2;
+
+        guiGraphics.drawString(font, Component.literal("Physique: " + physique), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.literal("Intellect: " + intellect), uStart, currentY, 0, false);
+        currentY += LINE_HEIGHT;
+
+        guiGraphics.drawString(font, Component.literal("Endurance: " + endurance), uStart, currentY, 0, false);
     }
 
     private void renderVillagerHearts(GuiGraphics guiGraphics, int x, int y) {

--- a/src/main/java/org/sosly/villagetale/item/LedgerItem.java
+++ b/src/main/java/org/sosly/villagetale/item/LedgerItem.java
@@ -173,11 +173,14 @@ public class LedgerItem extends Item {
 
         float health = villager.getHealth();
         int hunger = villager.getFoodData().getFoodLevel();
+        int physique = villager.getStats().getPhysique();
+        int endurance = villager.getStats().getEndurance();
+        int intellect = villager.getStats().getIntellect();
 
         List<ResourceLocation> knownRecipes = new ArrayList<>(villager.getRecipeKnowledge().known());
 
         SyncVillageCapability.send(serverPlayer, villageCapability, serverLevel.getServer());
-        OpenVillagerManagementScreen.send(serverPlayer, target.getId(), villager.getVillage().get(), homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
+        OpenVillagerManagementScreen.send(serverPlayer, target.getId(), villager.getVillage().get(), homeZoneId, workZoneId, inventory, health, hunger, physique, endurance, intellect, knownRecipes);
         return InteractionResult.CONSUME;
     }
 

--- a/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
+++ b/src/main/java/org/sosly/villagetale/network/packets/clientbound/OpenVillagerManagementScreen.java
@@ -30,9 +30,12 @@ public class OpenVillagerManagementScreen extends BasePacket {
     private final List<ItemStack> inventory;
     private final float health;
     private final int hunger;
+    private final int physique;
+    private final int endurance;
+    private final int intellect;
     private final List<ResourceLocation> knownRecipes;
 
-    private OpenVillagerManagementScreen(int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, List<ResourceLocation> knownRecipes) {
+    private OpenVillagerManagementScreen(int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, int physique, int endurance, int intellect, List<ResourceLocation> knownRecipes) {
         this.villagerEntityId = villagerEntityId;
         this.villageId = villageId;
         this.homeZoneId = homeZoneId;
@@ -40,11 +43,14 @@ public class OpenVillagerManagementScreen extends BasePacket {
         this.inventory = inventory;
         this.health = health;
         this.hunger = hunger;
+        this.physique = physique;
+        this.endurance = endurance;
+        this.intellect = intellect;
         this.knownRecipes = knownRecipes;
     }
 
-    public static void send(ServerPlayer player, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, List<ResourceLocation> knownRecipes) {
-        OpenVillagerManagementScreen packet = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
+    public static void send(ServerPlayer player, int villagerEntityId, UUID villageId, UUID homeZoneId, UUID workZoneId, List<ItemStack> inventory, float health, int hunger, int physique, int endurance, int intellect, List<ResourceLocation> knownRecipes) {
+        OpenVillagerManagementScreen packet = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, physique, endurance, intellect, knownRecipes);
         NetworkHandler.CHANNEL.sendTo(packet, player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
     }
 
@@ -65,6 +71,9 @@ public class OpenVillagerManagementScreen extends BasePacket {
         }
         buffer.writeFloat(msg.health);
         buffer.writeInt(msg.hunger);
+        buffer.writeInt(msg.physique);
+        buffer.writeInt(msg.endurance);
+        buffer.writeInt(msg.intellect);
         buffer.writeInt(msg.knownRecipes.size());
         for (ResourceLocation recipe : msg.knownRecipes) {
             buffer.writeResourceLocation(recipe);
@@ -86,12 +95,15 @@ public class OpenVillagerManagementScreen extends BasePacket {
             }
             float health = buffer.readFloat();
             int hunger = buffer.readInt();
+            int physique = buffer.readInt();
+            int endurance = buffer.readInt();
+            int intellect = buffer.readInt();
             int recipeCount = buffer.readInt();
             List<ResourceLocation> knownRecipes = new ArrayList<>();
             for (int i = 0; i < recipeCount; i++) {
                 knownRecipes.add(buffer.readResourceLocation());
             }
-            msg = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, knownRecipes);
+            msg = new OpenVillagerManagementScreen(villagerEntityId, villageId, homeZoneId, workZoneId, inventory, health, hunger, physique, endurance, intellect, knownRecipes);
         } catch (IndexOutOfBoundsException | IllegalArgumentException err) {
             VillageTale.LOGGER.error("Exception while reading OpenVillagerManagementScreen: {}", err.toString());
             return null;
@@ -112,7 +124,7 @@ public class OpenVillagerManagementScreen extends BasePacket {
             Minecraft mc = Minecraft.getInstance();
             LedgerScreen screen = new LedgerScreen(Component.translatable("villagetale.gui.villager_management.title"));
             screen.setLeftPage(new VillagerManagementPage(screen, msg.villagerEntityId, msg.villageId, msg.homeZoneId, msg.workZoneId));
-            screen.setRightPage(new VillagerStatsPage(screen, msg.villagerEntityId, msg.villageId, msg.health, msg.hunger));
+            screen.setRightPage(new VillagerStatsPage(screen, msg.villagerEntityId, msg.villageId, msg.health, msg.hunger, msg.physique, msg.endurance, msg.intellect));
             mc.setScreen(screen);
         });
     }

--- a/src/test/java/org/sosly/villagetale/data/VillagerStatsTest.java
+++ b/src/test/java/org/sosly/villagetale/data/VillagerStatsTest.java
@@ -1,0 +1,193 @@
+package org.sosly.villagetale.data;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.RandomSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VillagerStatsTest {
+    private VillagerStats stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = new VillagerStats();
+    }
+
+    @Test
+    void testConstructorDefaultsToMinimum() {
+        assertEquals(1, stats.getPhysique());
+        assertEquals(1, stats.getEndurance());
+        assertEquals(1, stats.getIntellect());
+    }
+
+    @Test
+    void testSetPhysiqueClampsToMin() {
+        stats.setPhysique(0);
+
+        assertEquals(1, stats.getPhysique());
+    }
+
+    @Test
+    void testSetPhysiqueClampsToMax() {
+        stats.setPhysique(25);
+
+        assertEquals(20, stats.getPhysique());
+    }
+
+    @Test
+    void testSetPhysiqueAcceptsValidValue() {
+        stats.setPhysique(10);
+
+        assertEquals(10, stats.getPhysique());
+    }
+
+    @Test
+    void testSetEnduranceClampsToMin() {
+        stats.setEndurance(-5);
+
+        assertEquals(1, stats.getEndurance());
+    }
+
+    @Test
+    void testSetEnduranceClampsToMax() {
+        stats.setEndurance(100);
+
+        assertEquals(20, stats.getEndurance());
+    }
+
+    @Test
+    void testSetEnduranceAcceptsValidValue() {
+        stats.setEndurance(15);
+
+        assertEquals(15, stats.getEndurance());
+    }
+
+    @Test
+    void testSetIntellectClampsToMin() {
+        stats.setIntellect(0);
+
+        assertEquals(1, stats.getIntellect());
+    }
+
+    @Test
+    void testSetIntellectClampsToMax() {
+        stats.setIntellect(30);
+
+        assertEquals(20, stats.getIntellect());
+    }
+
+    @Test
+    void testSetIntellectAcceptsValidValue() {
+        stats.setIntellect(8);
+
+        assertEquals(8, stats.getIntellect());
+    }
+
+    @Test
+    void testSerializeNBTCreatesCorrectTags() {
+        stats.setPhysique(10);
+        stats.setEndurance(15);
+        stats.setIntellect(8);
+
+        CompoundTag tag = stats.serializeNBT();
+
+        assertTrue(tag.contains("Physique"));
+        assertTrue(tag.contains("Endurance"));
+        assertTrue(tag.contains("Intellect"));
+        assertEquals(10, tag.getInt("Physique"));
+        assertEquals(15, tag.getInt("Endurance"));
+        assertEquals(8, tag.getInt("Intellect"));
+    }
+
+    @Test
+    void testDeserializeNBTWithValidData() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt("Physique", 12);
+        tag.putInt("Endurance", 9);
+        tag.putInt("Intellect", 14);
+        RandomSource random = mock(RandomSource.class);
+
+        stats.deserializeNBT(tag, random);
+
+        assertEquals(12, stats.getPhysique());
+        assertEquals(9, stats.getEndurance());
+        assertEquals(14, stats.getIntellect());
+    }
+
+    @Test
+    void testDeserializeNBTClampsOutOfBoundsValues() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt("Physique", 0);
+        tag.putInt("Endurance", 25);
+        tag.putInt("Intellect", -10);
+        RandomSource random = mock(RandomSource.class);
+
+        stats.deserializeNBT(tag, random);
+
+        assertEquals(1, stats.getPhysique());
+        assertEquals(20, stats.getEndurance());
+        assertEquals(1, stats.getIntellect());
+    }
+
+    @Test
+    void testDeserializeNBTWithMissingStatsGeneratesRandom() {
+        CompoundTag tag = new CompoundTag();
+        RandomSource random = mock(RandomSource.class);
+        when(random.nextInt(4)).thenReturn(2, 1, 3);
+
+        stats.deserializeNBT(tag, random);
+
+        assertEquals(3, stats.getPhysique());
+        assertEquals(2, stats.getEndurance());
+        assertEquals(4, stats.getIntellect());
+    }
+
+    @Test
+    void testDeserializeNBTWithPartialStatsGeneratesRandom() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt("Physique", 10);
+        RandomSource random = mock(RandomSource.class);
+        when(random.nextInt(4)).thenReturn(2, 1, 3);
+
+        stats.deserializeNBT(tag, random);
+
+        assertEquals(3, stats.getPhysique());
+        assertEquals(2, stats.getEndurance());
+        assertEquals(4, stats.getIntellect());
+    }
+
+    @Test
+    void testSerializeDeserializeRoundTrip() {
+        stats.setPhysique(7);
+        stats.setEndurance(13);
+        stats.setIntellect(18);
+
+        CompoundTag tag = stats.serializeNBT();
+
+        VillagerStats deserialized = new VillagerStats();
+        RandomSource random = mock(RandomSource.class);
+        deserialized.deserializeNBT(tag, random);
+
+        assertEquals(7, deserialized.getPhysique());
+        assertEquals(13, deserialized.getEndurance());
+        assertEquals(18, deserialized.getIntellect());
+    }
+
+    @Test
+    void testRandomGenerationStaysWithinBounds() {
+        CompoundTag tag = new CompoundTag();
+        RandomSource random = mock(RandomSource.class);
+        when(random.nextInt(4)).thenReturn(0, 3, 3);
+
+        stats.deserializeNBT(tag, random);
+
+        assertTrue(stats.getPhysique() >= 1 && stats.getPhysique() <= 4);
+        assertTrue(stats.getEndurance() >= 1 && stats.getEndurance() <= 4);
+        assertTrue(stats.getIntellect() >= 1 && stats.getIntellect() <= 4);
+    }
+}


### PR DESCRIPTION
Adds three core stats (Physique, Intellect, Endurance) to villagers, displayed in the villager management GUI. Stats are randomly assigned when villagers are first hired or loaded from legacy saves.

## Changes
- Created VillagerStats data class with NBT serialization/deserialization
- Integrated stats into Villager entity with automatic initialization on first load
- Extended network packet to transmit stats to client
- Updated villager management GUI to display stats in PIE order (Physique, Intellect, Endurance)
- Stats persist correctly across save/load cycles
- Both vanilla villagers (on conversion) and legacy villagers receive stats the same way

## Related Issues
Resolves #143

## Breaking Changes
None - legacy saves automatically migrate to include stats on first load